### PR TITLE
startFrame argument and indicated onset frame

### DIFF
--- a/release-packaging/HelpSource/Classes/FluidBufOnsetSlice.schelp
+++ b/release-packaging/HelpSource/Classes/FluidBufOnsetSlice.schelp
@@ -6,7 +6,7 @@ RELATED::  Guides/FluidCorpusManipulation, Guides/FluidBufMultiThreading
 DESCRIPTION::
 This class implements many spectral-based onset detection metrics, most of them taken from the literature. (http://www.dafx.ca/proceedings/papers/p_133.pdf) Some are already available in SuperCollider's LINK::Classes/Onsets:: object yet not as offline processes. It is part of the LINK:: Guides/FluidCorpusManipulation##Fluid Corpus Manipulation Toolkit::. For more explanations, learning material, and discussions on its musicianly uses, visit http://www.flucoma.org/
 
-The process will return a buffer which contains indices (in sample) of estimated starting points of different slices.
+The process will return a buffer which contains indices (in samples) of estimated starting points of different slices. If a startFrame argument is supplied, the starting point indices are still specified in terms of their location in the original buffer; they are not offset by the number startFrames.
 
 STRONG::Threading::
 


### PR DESCRIPTION
Added a note about using a startFrame argument; that the sample position of the original buffer is still what is returned.

This caught me off guard for a little bit and had to do some debugging, so I think it's good to make clear in the documents regarding what is returned in the features buffer.

It would be good to check if this non-offset is true for other FluidBuf* slicing objects as well.