### PR TITLE
Enable naming / sharing for all RT queryable model objects

### DIFF
--- a/include/wrapper/RealTimeBase.hpp
+++ b/include/wrapper/RealTimeBase.hpp
@@ -1,169 +1,229 @@
-#pragma once 
+#pragma once
 
 #include <SC_PlugIn.hpp>
 
-namespace fluid{
-namespace client{
-namespace impl{
-  template <typename Client, class Wrapper>
-  struct RealTimeBase
-  {    
-    using HostVector = FluidTensorView<float, 1>;
-    using Params = typename Client::ParamSetType;
-    template<typename T, bool>
-      struct doExpectedCount;
-      
-      template<typename T>
-      struct doExpectedCount<T, false>
-      {
-        static void count(const T& d,FloatControlsIter& c,Result& status)
-        {
-          if(!status.ok()) return;
-          
-          if(c.remain())
-          {
-            index statedSize = d.fixedSize;
-            
-            if(c.remain() < statedSize)
-                status =  {Result::Status::kError,"Ran out of arguments at ", d.name};
-            
-            //fastforward
-            for(index i=0; i < statedSize; ++i) c.next();
-            
-          }
-        }
-      };
+namespace fluid {
+namespace client {
+namespace impl {
 
-      template<typename T>
-      struct doExpectedCount<T, true>
-      {
-        static void count(const T& d,FloatControlsIter& c,Result& status)
-        {
-          if(!status.ok()) return;
-          
-          if(c.remain())
-          {
-            index statedSize = 1; 
-          
-            if(c.remain() < statedSize)
-                status =  {Result::Status::kError,"Ran out of arguments at ", d.name};
-            
-            //fastforward
-            for(index i=0; i < statedSize; ++i) c.next();
-            
-          }
-        }
-      };
-    template<size_t N, typename T>
-    struct ExpectedCount{
-      void operator ()(const T& descriptor,FloatControlsIter& c, Result& status)
-      {
-        doExpectedCount<T,IsSharedClientRef<typename T::type>::value>::count(descriptor,c,status);
-      }
-    };
 
-    Result expectedSize(FloatControlsIter& controls)
+template <typename Client, class Wrapper>
+struct RealTimeBase
+{
+  using IOMapFn = void (RealTimeBase::*)(SCUnit&, Client&);
+  using HostVector = FluidTensorView<float, 1>;
+  using Params = typename Client::ParamSetType;
+  template <typename T, bool>
+  struct doExpectedCount;
+
+  template <typename T>
+  struct doExpectedCount<T, false>
+  {
+    static void count(const T& d, FloatControlsIter& c, Result& status)
     {
-      if(controls.size() < Client::getParameterDescriptors().count())
+      if (!status.ok()) return;
+
+      if (c.remain())
       {
-        return {Result::Status::kError,"Fewer parameters than exepected. Got ", controls.size(), "expect at least", Client::getParameterDescriptors().count()};
+        index statedSize = d.fixedSize;
+
+        if (c.remain() < statedSize)
+          status = {Result::Status::kError, "Ran out of arguments at ", d.name};
+
+        // fastforward
+        for (index i = 0; i < statedSize; ++i) c.next();
       }
-      
-      Result countScan;
-      Client::getParameterDescriptors().template iterate<ExpectedCount>(
-          std::forward<FloatControlsIter&>(controls),
-          std::forward<Result&>(countScan));
-      return countScan;
+    }
+  };
+
+  template <typename T>
+  struct doExpectedCount<T, true>
+  {
+    static void count(const T& d, FloatControlsIter& c, Result& status)
+    {
+      if (!status.ok()) return;
+
+      if (c.remain())
+      {
+        index statedSize = 1;
+
+        if (c.remain() < statedSize)
+          status = {Result::Status::kError, "Ran out of arguments at ", d.name};
+
+        // fastforward
+        for (index i = 0; i < statedSize; ++i) c.next();
+      }
+    }
+  };
+  template <size_t N, typename T>
+  struct ExpectedCount
+  {
+    void operator()(const T& descriptor, FloatControlsIter& c, Result& status)
+    {
+      doExpectedCount<T, IsSharedClientRef<typename T::type>::value>::count(
+          descriptor, c, status);
+    }
+  };
+
+  Result expectedSize(FloatControlsIter& controls)
+  {
+    if (controls.size() < Client::getParameterDescriptors().count())
+    {
+      return {Result::Status::kError, "Fewer parameters than exepected. Got ",
+              controls.size(), "expect at least",
+              Client::getParameterDescriptors().count()};
     }
 
-    // static index ControlOffset(Unit* unit) { return unit->mSpecialIndex + 1; }
-    // static index ControlSize(Unit* unit) { return static_cast<index>(unit->mNumInputs) - unit->mSpecialIndex - 1  -(IsModel_t<Client>::value ? 1 : 0); }
-    
-    void init(SCUnit& unit, Client& client, FloatControlsIter& controls)
+    Result countScan;
+    Client::getParameterDescriptors().template iterate<ExpectedCount>(
+        std::forward<FloatControlsIter&>(controls),
+        std::forward<Result&>(countScan));
+    return countScan;
+  }
+
+  void init(SCUnit& unit, Client& client, FloatControlsIter& controls)
+  {
+    assert(!(client.audioChannelsOut() > 0 &&
+             client.controlChannelsOut().count > 0) &&
+           "Client can't have both audio and control outputs");
+    client.sampleRate(unit.fullSampleRate());
+    mInputConnections.reserve(asUnsigned(client.audioChannelsIn()));
+    mOutputConnections.reserve(asUnsigned(client.audioChannelsOut()));
+
+    Result r;
+    if (!(r = expectedSize(controls)).ok())
     {
-      assert(!(client.audioChannelsOut() > 0 && client.controlChannelsOut() > 0) &&"Client can't have both audio and control outputs");
-      // consoltr.reset(unit.mInBuf + unit.mSpecialIndex + 1);
-      client.sampleRate(unit.fullSampleRate());
-      mInputConnections.reserve(asUnsigned(client.audioChannelsIn()));
-      mOutputConnections.reserve(asUnsigned(client.audioChannelsOut()));
+      std::cout << "ERROR: " << Wrapper::getName()
+                << " wrong number of arguments." << r.message() << std::endl;
+      return;
+    }
+
+    if (client.audioChannelsIn())
+    {
       mAudioInputs.reserve(asUnsigned(client.audioChannelsIn()));
-      mOutputs.reserve(asUnsigned(
-          std::max(client.audioChannelsOut(), client.controlChannelsOut())));
-
-
-          Result r;
-          if(!(r = expectedSize(controls)).ok())
-          {
-//            mCalcFunc = Wrapper::getInterfaceTable()->fClearUnitOutputs;
-            std::cout
-                << "ERROR: " << Wrapper::getName()
-                << " wrong number of arguments."
-                << r.message()
-                << std::endl;
-            return;
-          }
-
-
       for (index i = 0; i < client.audioChannelsIn(); ++i)
       {
         mInputConnections.emplace_back(unit.isAudioRateIn(static_cast<int>(i)));
         mAudioInputs.emplace_back(nullptr, 0, 0);
       }
+      mInputMapper = &RealTimeBase::mapAudioInputs;
+    }
+    else if (client.controlChannelsIn())
+    {
+      mControlInputBuffer.resize(unit.mSpecialIndex + 1);
+      mAudioInputs.emplace_back(mControlInputBuffer);
+      mInputMapper = &RealTimeBase::mapControlInputs;
+    }
 
+    index outputSize = client.controlChannelsOut().size > 0
+                           ? std::max(client.audioChannelsOut(),
+                                      client.controlChannelsOut().size)
+                           : unit.mSpecialIndex + 1;
+    mOutputs.reserve(asUnsigned(outputSize));
+
+    if (client.audioChannelsOut())
+    {
       for (index i = 0; i < client.audioChannelsOut(); ++i)
       {
         mOutputConnections.emplace_back(true);
         mOutputs.emplace_back(nullptr, 0, 0);
       }
-
-      for (index i = 0; i < client.controlChannelsOut(); ++i)
-      { 
-        mOutputs.emplace_back(nullptr, 0, 0); 
+      
+      mOutMapperPre = &RealTimeBase::mapAudioOutputs;
+      mOutMapperPost = &RealTimeBase::mapNoOp;
+    }
+    else
+    {
+      index totalControlOutputs =
+          client.controlChannelsOut().count * outputSize;
+      mControlOutputBuffer.resize(totalControlOutputs);
+      for (index i = 0; i < client.controlChannelsOut().count; ++i)
+      {
+        mOutputs.emplace_back(
+            mControlOutputBuffer(fluid::Slice(i * outputSize, outputSize)));
       }
-   }
-    
-   void next(SCUnit& unit, Client& client,Params& params,FloatControlsIter& controls,bool updateParams = true)
-   {   
-     bool trig =  IsModel_t<Client>::value ? !mPrevTrig  && unit.in0(0) > 0 : false;
 
-     mPrevTrig = trig;
-     
-     if(updateParams)
-     {
+      mOutMapperPre = &RealTimeBase::mapNoOp;
+      mOutMapperPost = &RealTimeBase::mapControlOutputs;
+    }
+  }
+
+  void mapNoOp(SCUnit&, Client&) {}
+
+  void mapAudioInputs(SCUnit& unit, Client& client)
+  {
+    for (index i = 0; i < client.audioChannelsIn(); ++i)
+    {
+      assert(i <= std::numeric_limits<int>::max());
+      if (mInputConnections[asUnsigned(i)])
+        mAudioInputs[asUnsigned(i)].reset(
+            const_cast<float*>(unit.in(static_cast<int>(i))), 0,
+            unit.fullBufferSize());
+    }
+  }
+
+  void mapAudioOutputs(SCUnit& unit, Client& client)
+  {
+    for (index i = 0; i < client.audioChannelsOut(); ++i)
+    {
+      assert(i <= std::numeric_limits<int>::max());
+      if (mOutputConnections[asUnsigned(i)])
+        mOutputs[asUnsigned(i)].reset(unit.out(static_cast<int>(i)), 0,
+                                      unit.fullBufferSize());
+    }
+  }
+
+  void mapControlInputs(SCUnit& unit, Client& client)
+  {
+    for (index i = 0; i < unit.mSpecialIndex + 1; ++i)
+    {
+      assert(i <= std::numeric_limits<int>::max());
+      mControlInputBuffer[asUnsigned(i)] = unit.in0(static_cast<int>(i));
+    }
+  }
+
+  void mapControlOutputs(SCUnit& unit, Client& client)
+  {
+    for (index i = 0; i < mControlOutputBuffer.size(); ++i)
+    {
+      assert(i <= std::numeric_limits<int>::max());
+      unit.out0(static_cast<int>(i)) = mControlOutputBuffer(i);
+    }
+  }
+
+  void next(SCUnit& unit, Client& client, Params& params,
+            FloatControlsIter& controls, bool updateParams = true)
+  {
+    bool trig =
+        IsModel_t<Client>::value ? !mPrevTrig && unit.in0(0) > 0 : false;
+
+    mPrevTrig = trig;
+
+    if (updateParams)
+    {
       Wrapper::setParams(&unit, params, controls);
       params.constrainParameterValuesRT(nullptr);
-     }
-     
-     for (index i = 0; i < client.audioChannelsIn(); ++i)
-     {
-        assert(i <= std::numeric_limits<int>::max());
-       if (mInputConnections[asUnsigned(i)])
-         mAudioInputs[asUnsigned(i)].reset(const_cast<float*>(unit.in(static_cast<int>(i))), 0,unit.fullBufferSize());
-     }
-     
-     for (index i = 0; i < client.audioChannelsOut(); ++i)
-     {
-       assert(i <= std::numeric_limits<int>::max());
-       if (mOutputConnections[asUnsigned(i)])
-         mOutputs[asUnsigned(i)].reset(unit.out(static_cast<int>(i)), 0,
-                                       unit.fullBufferSize());
-     }
-     
-     for (index i = 0; i < client.controlChannelsOut(); ++i)
-     {
-       assert(i <= std::numeric_limits<int>::max());
-       mOutputs[asUnsigned(i)].reset(unit.out(static_cast<int>(i)), 0, 1);
-     }
-     client.process(mAudioInputs, mOutputs, mContext);
-   }  
-  private:
-    std::vector<bool>       mInputConnections;
-    std::vector<bool>       mOutputConnections;
-    std::vector<HostVector> mAudioInputs;
-    std::vector<HostVector> mOutputs;
-    FluidContext            mContext;
-    bool                    mPrevTrig;    
-  };
-}
-}
-}
+    }
+
+    (this->*mInputMapper)(unit, client);
+    (this->*mOutMapperPre)(unit, client);
+    client.process(mAudioInputs, mOutputs, mContext);
+    (this->*mOutMapperPost)(unit, client);
+  }
+
+private:
+  std::vector<bool>       mInputConnections;
+  std::vector<bool>       mOutputConnections;
+  std::vector<HostVector> mAudioInputs;
+  std::vector<HostVector> mOutputs;
+  FluidTensor<float, 1>   mControlInputBuffer;
+  FluidTensor<float, 1>   mControlOutputBuffer;
+  FluidContext            mContext;
+  bool                    mPrevTrig;
+  IOMapFn                 mInputMapper;
+  IOMapFn                 mOutMapperPre;
+  IOMapFn                 mOutMapperPost;
+};
+} // namespace impl
+} // namespace client
+} // namespace fluid

--- a/release-packaging/Classes/FluidKDTree.sc
+++ b/release-packaging/Classes/FluidKDTree.sc
@@ -1,13 +1,12 @@
-FluidKDTree : FluidRealTimeModel
+FluidKDTree : FluidModelObject
  {
 
-    var neighbours,radius,lookup;
+    var neighbours,radius;
 
-    *new{ |server, numNeighbours = 1, radius = 0, lookupDataSet|
-        ^super.new(server,[numNeighbours,radius,lookupDataSet ? -1])
+    *new{ |server, numNeighbours = 1, radius = 0|
+        ^super.new(server,[numNeighbours,radius ? -1])
         .numNeighbours_(numNeighbours)
-        .radius_(radius)
-        .lookupDataSet_(lookupDataSet);
+        .radius_(radius);
     }
 
     numNeighbours_{|k|neighbours = k.asInteger; }
@@ -16,10 +15,7 @@ FluidKDTree : FluidRealTimeModel
     radius_{|r| radius = r.asUGenInput;}
     radius{ ^radius; }
 
-    lookupDataSet_{|ds| lookup = ds ? -1; }
-    lookupDataSet{|ds|  ^ (lookup ? -1) }
-
-    prGetParams{^[this.numNeighbours,this.radius,this.lookupDataSet,-1,-1];}
+    prGetParams{^[this.id, this.numNeighbours,this.radius];}
 
     fitMsg{ |dataSet| ^this.prMakeMsg(\fit,this.id,dataSet.id);}
 
@@ -47,16 +43,26 @@ FluidKDTree : FluidRealTimeModel
 	}
 
     kr{|trig, inputBuffer,outputBuffer, numNeighbours = 1, lookupDataSet|
-        this.numNeighbours_(numNeighbours);
+/*        this.numNeighbours_(numNeighbours);
         lookupDataSet = lookupDataSet ? -1;
-        this.lookupDataSet_(lookupDataSet);
+        this.lookupDataSet_(lookupDataSet);*/
 
-        ^FluidKDTreeQuery.kr(K2A.ar(trig),
-                this, this.numNeighbours, this.radius, this.lookupDataSet.asUGenInput,
-                this.prEncodeBuffer(inputBuffer),
-                this.prEncodeBuffer(outputBuffer));
+        ^FluidKDTreeQuery.kr(trig,
+            this, numNeighbours, this.radius,lookupDataSet.asUGenInput,
+            inputBuffer,outputBuffer);
     }
 
 }
 
-FluidKDTreeQuery : FluidRTQuery {}
+FluidKDTreeQuery : FluidRTMultiOutUGen
+{
+    *kr{ |trig, tree, numNeighbours, radius,lookupDataSet, inputBuffer, outputBuffer |
+        ^this.multiNew('control',trig, tree.asUGenInput, numNeighbours, radius,lookupDataSet!?(_.asUGenInput)??{-1}, inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+
+}

--- a/release-packaging/Classes/FluidKMeans.sc
+++ b/release-packaging/Classes/FluidKMeans.sc
@@ -1,4 +1,4 @@
-FluidKMeans : FluidRealTimeModel {
+FluidKMeans : FluidModelObject {
 
 	var clusters, maxiter;
 
@@ -14,7 +14,7 @@ FluidKMeans : FluidRealTimeModel {
 	maxIter_{|i| maxiter = i.asInteger}
 	maxIter{ ^maxiter }
 
-	prGetParams{^[this.numClusters,this.maxIter,-1,-1];}
+	prGetParams{^[this.id,this.numClusters,this.maxIter];}
 
 	fitMsg{ |dataSet| ^this.prMakeMsg(\fit,id,dataSet.id);}
 
@@ -111,11 +111,21 @@ FluidKMeans : FluidRealTimeModel {
 	}
 
 	kr{|trig, inputBuffer,outputBuffer|
-		^FluidKMeansQuery.kr(K2A.ar(trig),
-			this, clusters, maxiter,
-			this.prEncodeBuffer(inputBuffer),
-			this.prEncodeBuffer(outputBuffer));
+        ^FluidKMeansQuery.kr(trig,
+            this,
+            this.prEncodeBuffer(inputBuffer),
+            this.prEncodeBuffer(outputBuffer));
 	}
 }
 
-FluidKMeansQuery : FluidRTQuery {}
+FluidKMeansQuery : FluidRTMultiOutUGen {
+
+    *kr{ |trig, model,inputBuffer, outputBuffer |
+        ^this.multiNew('control',trig, model.asUGenInput,inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+}

--- a/release-packaging/Classes/FluidKNNClassifier.sc
+++ b/release-packaging/Classes/FluidKNNClassifier.sc
@@ -1,4 +1,4 @@
-FluidKNNClassifier : FluidRealTimeModel {
+FluidKNNClassifier : FluidModelObject {
 
     var <>numNeighbours, <>weight;
 
@@ -8,7 +8,7 @@ FluidKNNClassifier : FluidRealTimeModel {
         .weight_(weight);
 	}
 
-    prGetParams{^[this.numNeighbours,this.weight,-1,-1];}
+    prGetParams{^[this.id,this.numNeighbours,this.weight];}
 
     fitMsg{|dataSet, labelSet|
         ^this.prMakeMsg(\fit, id, dataSet.id, labelSet.id)
@@ -38,7 +38,7 @@ FluidKNNClassifier : FluidRealTimeModel {
 	}
 
     kr{|trig, inputBuffer,outputBuffer|
-        ^FluidKNNClassifierQuery.kr(K2A.ar(trig),
+        ^FluidKNNClassifierQuery.kr(trig,
                 this, this.numNeighbours, this.weight,
                 this.prEncodeBuffer(inputBuffer),
                 this.prEncodeBuffer(outputBuffer));
@@ -46,4 +46,17 @@ FluidKNNClassifier : FluidRealTimeModel {
 
 }
 
-FluidKNNClassifierQuery : FluidRTQuery {}
+FluidKNNClassifierQuery : FluidRTMultiOutUGen {
+
+    *kr{ |trig, model,numNeighbours = 3, weight = 1,inputBuffer, outputBuffer |
+        ^this.multiNew('control',trig, model.asUGenInput,
+            numNeighbours,weight,
+            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+}
+

--- a/release-packaging/Classes/FluidKNNRegressor.sc
+++ b/release-packaging/Classes/FluidKNNRegressor.sc
@@ -1,4 +1,4 @@
-FluidKNNRegressor : FluidRealTimeModel {
+FluidKNNRegressor : FluidModelObject {
 
     var <>numNeighbours, <>weight;
 
@@ -8,7 +8,7 @@ FluidKNNRegressor : FluidRealTimeModel {
         .weight_(weight);
 	}
 
-    prGetParams{^[this.numNeighbours,this.weight,-1,-1];}
+    prGetParams{^[this.id,this.numNeighbours,this.weight,-1,-1];}
 
     fitMsg{|sourceDataSet, targetDataSet|
         ^this.prMakeMsg(\fit,this.id,sourceDataSet.id,targetDataSet.id)

--- a/release-packaging/Classes/FluidKNNRegressor.sc
+++ b/release-packaging/Classes/FluidKNNRegressor.sc
@@ -45,4 +45,16 @@ FluidKNNRegressor : FluidRealTimeModel {
     }
 }
 
-FluidKNNRegressorQuery : FluidRTQuery {}
+FluidKNNRegressorQuery : FluidRTMultiOutUGen {
+
+    *kr{ |trig, model,numNeighbours = 3, weight = 1,inputBuffer, outputBuffer |
+        ^this.multiNew('control',trig, model.asUGenInput,
+            numNeighbours,weight,
+            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+}

--- a/release-packaging/Classes/FluidNormalize.sc
+++ b/release-packaging/Classes/FluidNormalize.sc
@@ -1,4 +1,4 @@
-FluidNormalize : FluidRealTimeModel {
+FluidNormalize : FluidModelObject {
 
     var <>min, <>max, <>invert;
 
@@ -8,7 +8,7 @@ FluidNormalize : FluidRealTimeModel {
 	}
 
     prGetParams{
-        ^[this.min,this.max,this.invert,-1,-1];
+        ^[this.id, this.min,this.max,this.invert,-1,-1];
     }
 
 
@@ -52,7 +52,7 @@ FluidNormalize : FluidRealTimeModel {
         this.prSendMsg(this.transformPointMsg(sourceBuffer, destBuffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer,min,max,invert|
+    kr{|trig, inputBuffer,outputBuffer,min = 0 ,max = 1,invert = 0|
 
         min = min ? this.min;
         max = max ? this.max;
@@ -60,11 +60,24 @@ FluidNormalize : FluidRealTimeModel {
 
         this.min_(min).max_(max).invert_(invert);
 
-        ^FluidNormalizeQuery.kr( K2A.ar(trig),
-                this, this.min, this.max, this.invert, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer)); 
+        ^FluidNormalizeQuery.kr(trig,
+                this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.min, this.max, this.invert);
     }
 
 
 }
 
-FluidNormalizeQuery : FluidRTQuery {}
+FluidNormalizeQuery : FluidRTMultiOutUGen {
+
+    *kr{ |trig, model,inputBuffer,outputBuffer,min = 0 ,max = 1,invert = 0|
+        inputBuffer.asUGenInput.postln;
+        ^this.multiNew('control',trig, model.asUGenInput,
+            min,max,invert,
+            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+}

--- a/release-packaging/Classes/FluidPCA.sc
+++ b/release-packaging/Classes/FluidPCA.sc
@@ -1,4 +1,4 @@
-FluidPCA : FluidRealTimeModel{
+FluidPCA : FluidModelObject{
 
     var <>numDimensions;
 
@@ -7,7 +7,7 @@ FluidPCA : FluidRealTimeModel{
     }
 
     prGetParams{
-        ^[numDimensions,-1,-1];
+        ^[this.id, numDimensions];
     }
 
     fitMsg{|dataSet|
@@ -55,9 +55,20 @@ FluidPCA : FluidRealTimeModel{
         numDimensions = numDimensions ? this.numDimensions;
         this.numDimensions_(numDimensions);
 
-        ^FluidPCAQuery.kr(K2A.ar(trig),this, this.numDimensions, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer));
+        ^FluidPCAQuery.kr(trig ,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.numDimensions);
     }
 
 }
 
-FluidPCAQuery : FluidRTQuery {}
+FluidPCAQuery :  FluidRTMultiOutUGen {
+       *kr{ |trig, model, inputBuffer,outputBuffer,numDimensions|
+        ^this.multiNew('control',trig, model.asUGenInput,
+            numDimensions,
+            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+}

--- a/release-packaging/Classes/FluidRobustScale.sc
+++ b/release-packaging/Classes/FluidRobustScale.sc
@@ -1,4 +1,4 @@
-FluidRobustScale : FluidRealTimeModel {
+FluidRobustScale : FluidModelObject {
 
     var <>low, <>high, <>invert;
 
@@ -8,7 +8,7 @@ FluidRobustScale : FluidRealTimeModel {
 	}
 
     prGetParams{
-        ^[this.low,this.high,this.invert,-1,-1];
+        ^[this.id,this.low,this.high,this.invert];
     }
 
 
@@ -52,18 +52,27 @@ FluidRobustScale : FluidRealTimeModel {
         this.prSendMsg(this.transformPointMsg(sourceBuffer, destBuffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer,low,high,invert|
+    kr{|trig, inputBuffer,outputBuffer,invert|
 
-        low = low ? this.low;
-        high = high ? this.high;
 		invert = invert ? this.invert;
 
-        this.low_(low).high_(high).invert_(invert);
+        // this.invert_(invert);
 
-        ^FluidRobustScaleQuery.kr(K2A.ar(trig),this, this.low, this.high, this.invert, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer));
+        ^FluidRobustScaleQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), invert,);
     }
 
 
 }
 
-FluidRobustScaleQuery : FluidRTQuery {}
+FluidRobustScaleQuery : FluidRTMultiOutUGen {
+       *kr{ |trig, model, inputBuffer,outputBuffer,invert|
+        ^this.multiNew('control',trig, model.asUGenInput,
+            invert,
+            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+}

--- a/release-packaging/Classes/FluidStandardize.sc
+++ b/release-packaging/Classes/FluidStandardize.sc
@@ -1,4 +1,4 @@
-FluidStandardize : FluidRealTimeModel {
+FluidStandardize : FluidModelObject {
 
     var <>invert;
 
@@ -7,7 +7,7 @@ FluidStandardize : FluidRealTimeModel {
 	}
 
     prGetParams{
-        ^[this.invert, -1, 1];
+        ^[this.id, this.invert];
     }
 
 	fitMsg{|dataSet|
@@ -52,8 +52,19 @@ FluidStandardize : FluidRealTimeModel {
         invert = invert ? this.invert;
         this.invert_(invert);
 
-        ^FluidStandardizeQuery.kr(K2A.ar(trig),this, this.invert, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer));
+        ^FluidStandardizeQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.invert);
     }
 }
 
-FluidStandardizeQuery : FluidRTQuery {}
+FluidStandardizeQuery : FluidRTMultiOutUGen {
+   *kr{ |trig, model,inputBuffer,outputBuffer,invert = 0|
+        ^this.multiNew('control',trig, model.asUGenInput,
+            invert,
+            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+}

--- a/release-packaging/Classes/FluidStats.sc
+++ b/release-packaging/Classes/FluidStats.sc
@@ -1,0 +1,51 @@
+FluidStats : MultiOutUGen {
+
+    var <channels;
+
+	*kr { arg inputs;
+        // ^super.new.rate_('control').inputs_(inputs.asArray++0).initOutputs(inputs.asArray.size);
+        ^this.new1('control',inputs);
+	}
+
+	init {arg ...theInputs;
+		inputs = theInputs ++ 0;
+		^this.initOutputs(inputs.asArray.size - 1,rate);
+	}
+
+	checkInputs {
+/*		if(inputs.any.rate != 'control') {
+			^"input array input is not control rate";
+		};*/
+        this.specialIndex = (inputs.size - 2).min(0);
+        this.specialIndex.postln;
+		^this.checkValidInputs;
+	}
+
+    initOutputs{|numChans,rate|
+        if(numChans.isNil or: {numChans < 1})
+        {
+            Error("No input channels").throw
+        };
+
+        channels = Array.fill(numChans * 2, { |i|
+            // Array.fill(numChans,{ |j|
+            OutputProxy('control',this,i);
+        });
+// });
+        ^channels;
+    }
+
+    // synthIndex_ { arg index;
+    //     synthIndex = index;
+    //     channels.do{
+    //         arg outputGroup;
+    //         outputGroup.do{
+    //             arg output;
+    //             output.synthIndex_(index);
+    //         }
+    //     }
+    // }
+
+
+    numOutputs { ^(channels.size); }
+}

--- a/release-packaging/Classes/FluidUMAP.sc
+++ b/release-packaging/Classes/FluidUMAP.sc
@@ -1,4 +1,4 @@
-FluidUMAP : FluidRealTimeModel {
+FluidUMAP : FluidModelObject {
 
     var <>numDimensions, <>numNeighbours, <>minDist, <>iterations, <>learnRate;
 
@@ -13,12 +13,12 @@ FluidUMAP : FluidRealTimeModel {
 
     prGetParams{
         ^[
+            this.id,
             this.numDimensions,
             this.numNeighbours,
             this.minDist,
             this.iterations,
             this.learnRate,
-			-1,-1
         ]
     }
 
@@ -68,13 +68,8 @@ FluidUMAP : FluidRealTimeModel {
         numDimensions = numDimensions ? this.numDimensions;
         this.numDimensions_(numDimensions);
 
-        ^FluidUMAPQuery.kr(K2A.ar(trig),
+        ^FluidUMAPQuery.kr(trig,
             this,
-			this.numDimensions,
-			this.numNeighbours,
-            this.minDist,
-            this.iterations,
-            this.learnRate,
 			this.prEncodeBuffer(inputBuffer),
 			this.prEncodeBuffer(outputBuffer));
     }
@@ -84,4 +79,14 @@ FluidUMAP : FluidRealTimeModel {
 	size { |action|}
 }
 
-FluidUMAPQuery : FluidRTQuery {}
+FluidUMAPQuery : FluidRTMultiOutUGen {
+    *kr{ |trig, model, inputBuffer,outputBuffer|
+        ^this.multiNew('control',trig, model.asUGenInput,
+            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+    }
+
+    init { arg ... theInputs;
+		inputs = theInputs;
+		^this.initOutputs(1, rate);
+	}
+}

--- a/src/FluidManipulation/FluidManipulation.cpp
+++ b/src/FluidManipulation/FluidManipulation.cpp
@@ -45,8 +45,8 @@ PluginLoad(FluidSTFTUGen)
   makeSCWrapper<NRTThreadedNormalizeClient>("FluidNormalize",ft);
   makeSCWrapper<RTNormalizeQueryClient>("FluidNormalizeQuery",ft);
   
-  makeSCWrapper<RTRobustScaleClient>("FluidRobustScale",ft);
-  
+  makeSCWrapper<NRTThreadedRobustScaleClient>("FluidRobustScale",ft);
+  makeSCWrapper<RTRobustScaleQueryClient>("FluidRobustScaleQuery",ft);
   makeSCWrapper<NRTThreadedStandardizeClient>("FluidStandardize",ft);
   makeSCWrapper<RTStandardizeQueryClient>("FluidStandardizeQuery",ft);
   

--- a/src/FluidManipulation/FluidManipulation.cpp
+++ b/src/FluidManipulation/FluidManipulation.cpp
@@ -46,7 +46,10 @@ PluginLoad(FluidSTFTUGen)
   makeSCWrapper<RTNormalizeQueryClient>("FluidNormalizeQuery",ft);
   
   makeSCWrapper<RTRobustScaleClient>("FluidRobustScale",ft);
-  makeSCWrapper<RTStandardizeClient>("FluidStandardize",ft);
+  
+  makeSCWrapper<NRTThreadedStandardizeClient>("FluidStandardize",ft);
+  makeSCWrapper<RTStandardizeQueryClient>("FluidStandardizeQuery",ft);
+  
   makeSCWrapper<RTPCAClient>("FluidPCA",ft);
   makeSCWrapper<NRTThreadedMDSClient>("FluidMDS",ft);
   makeSCWrapper<RTUMAPClient>("FluidUMAP",ft);

--- a/src/FluidManipulation/FluidManipulation.cpp
+++ b/src/FluidManipulation/FluidManipulation.cpp
@@ -29,7 +29,10 @@ PluginLoad(FluidSTFTUGen)
   makeSCWrapper<NRTThreadedDataSetClient>("FluidDataSet",ft);
   makeSCWrapper<NRTThreadedDataSetQueryClient>("FluidDataSetQuery",ft);
   makeSCWrapper<NRTThreadedLabelSetClient>("FluidLabelSet",ft);
-  makeSCWrapper<RTKDTreeClient>("FluidKDTree",ft);
+  
+  makeSCWrapper<NRTThreadedKDTreeClient>("FluidKDTree",ft);
+  makeSCWrapper<RTKDTreeQueryClient>("FluidKDTreeQuery",ft);
+  
   makeSCWrapper<RTKMeansClient>("FluidKMeans",ft);
   makeSCWrapper<RTKNNClassifierClient>("FluidKNNClassifier",ft);
   makeSCWrapper<RTKNNRegressorClient>("FluidKNNRegressor",ft);

--- a/src/FluidManipulation/FluidManipulation.cpp
+++ b/src/FluidManipulation/FluidManipulation.cpp
@@ -42,7 +42,9 @@ PluginLoad(FluidSTFTUGen)
   makeSCWrapper<NRTThreadedKNNRegressorClient>("FluidKNNRegressor",ft);
   makeSCWrapper<RTKNNRegressorQueryClient>("FluidKNNRegressorQuery",ft);
   
-  makeSCWrapper<RTNormalizeClient>("FluidNormalize",ft);
+  makeSCWrapper<NRTThreadedNormalizeClient>("FluidNormalize",ft);
+  makeSCWrapper<RTNormalizeQueryClient>("FluidNormalizeQuery",ft);
+  
   makeSCWrapper<RTRobustScaleClient>("FluidRobustScale",ft);
   makeSCWrapper<RTStandardizeClient>("FluidStandardize",ft);
   makeSCWrapper<RTPCAClient>("FluidPCA",ft);

--- a/src/FluidManipulation/FluidManipulation.cpp
+++ b/src/FluidManipulation/FluidManipulation.cpp
@@ -33,7 +33,10 @@ PluginLoad(FluidSTFTUGen)
   makeSCWrapper<NRTThreadedKDTreeClient>("FluidKDTree",ft);
   makeSCWrapper<RTKDTreeQueryClient>("FluidKDTreeQuery",ft);
   
-  makeSCWrapper<RTKMeansClient>("FluidKMeans",ft);
+  makeSCWrapper<NRTThreadedKMeansClient>("FluidKMeans",ft);
+  makeSCWrapper<RTKMeansQueryClient>("FluidKMeansQuery",ft);
+  
+  
   makeSCWrapper<RTKNNClassifierClient>("FluidKNNClassifier",ft);
   makeSCWrapper<RTKNNRegressorClient>("FluidKNNRegressor",ft);
   makeSCWrapper<RTNormalizeClient>("FluidNormalize",ft);

--- a/src/FluidManipulation/FluidManipulation.cpp
+++ b/src/FluidManipulation/FluidManipulation.cpp
@@ -39,7 +39,9 @@ PluginLoad(FluidSTFTUGen)
   makeSCWrapper<NRTThreadedKNNClassifierClient>("FluidKNNClassifier",ft);
   makeSCWrapper<RTKNNClassifierQueryClient>("FluidKNNClassifierQuery",ft);
   
-  makeSCWrapper<RTKNNRegressorClient>("FluidKNNRegressor",ft);
+  makeSCWrapper<NRTThreadedKNNRegressorClient>("FluidKNNRegressor",ft);
+  makeSCWrapper<RTKNNRegressorQueryClient>("FluidKNNRegressorQuery",ft);
+  
   makeSCWrapper<RTNormalizeClient>("FluidNormalize",ft);
   makeSCWrapper<RTRobustScaleClient>("FluidRobustScale",ft);
   makeSCWrapper<RTStandardizeClient>("FluidStandardize",ft);

--- a/src/FluidManipulation/FluidManipulation.cpp
+++ b/src/FluidManipulation/FluidManipulation.cpp
@@ -36,8 +36,9 @@ PluginLoad(FluidSTFTUGen)
   makeSCWrapper<NRTThreadedKMeansClient>("FluidKMeans",ft);
   makeSCWrapper<RTKMeansQueryClient>("FluidKMeansQuery",ft);
   
+  makeSCWrapper<NRTThreadedKNNClassifierClient>("FluidKNNClassifier",ft);
+  makeSCWrapper<RTKNNClassifierQueryClient>("FluidKNNClassifierQuery",ft);
   
-  makeSCWrapper<RTKNNClassifierClient>("FluidKNNClassifier",ft);
   makeSCWrapper<RTKNNRegressorClient>("FluidKNNRegressor",ft);
   makeSCWrapper<RTNormalizeClient>("FluidNormalize",ft);
   makeSCWrapper<RTRobustScaleClient>("FluidRobustScale",ft);

--- a/src/FluidManipulation/FluidManipulation.cpp
+++ b/src/FluidManipulation/FluidManipulation.cpp
@@ -47,14 +47,25 @@ PluginLoad(FluidSTFTUGen)
   
   makeSCWrapper<NRTThreadedRobustScaleClient>("FluidRobustScale",ft);
   makeSCWrapper<RTRobustScaleQueryClient>("FluidRobustScaleQuery",ft);
+  
   makeSCWrapper<NRTThreadedStandardizeClient>("FluidStandardize",ft);
   makeSCWrapper<RTStandardizeQueryClient>("FluidStandardizeQuery",ft);
   
-  makeSCWrapper<RTPCAClient>("FluidPCA",ft);
+  makeSCWrapper<NRTThreadedPCAClient>("FluidPCA",ft);  
+  makeSCWrapper<RTPCAQueryClient>("FluidPCAQuery",ft);
+  
   makeSCWrapper<NRTThreadedMDSClient>("FluidMDS",ft);
-  makeSCWrapper<RTUMAPClient>("FluidUMAP",ft);
+  
+  makeSCWrapper<NRTThreadedUMAPClient>("FluidUMAP",ft);
+  makeSCWrapper<RTUMAPQueryClient>("FluidUMAPQuery",ft);
+  
   makeSCWrapper<NRTThreadedDataSetWriter>("FluidDataSetWr", ft);
-  makeSCWrapper<RTMLPRegressorClient>("FluidMLPRegressor",ft);
-  makeSCWrapper<RTMLPClassifierClient>("FluidMLPClassifier",ft);
+  
+  makeSCWrapper<NRTThreadedMLPRegressorClient>("FluidMLPRegressor",ft);
+  makeSCWrapper<RTMLPRegressorQueryClient>("FluidMLPRegressorQuery",ft);
+  
+  makeSCWrapper<NRTThreadedMLPClassifierClient>("FluidMLPClassifier",ft);
+  makeSCWrapper<RTMLPClassifierQueryClient>("FluidMLPClassifierQuery",ft);
+  
   makeSCWrapper<NRTThreadedGridClient>("FluidGrid",ft);
 }

--- a/src/FluidStats/CMakeLists.txt
+++ b/src/FluidStats/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+cmake_minimum_required(VERSION 3.11)
+
+get_filename_component(PLUGIN ${CMAKE_CURRENT_LIST_DIR} NAME_WE)
+message("Configuring ${PLUGIN}")
+set(FILENAME ${PLUGIN}.cpp)
+
+add_library(
+  ${PLUGIN}
+  MODULE
+  ${FILENAME}
+)
+
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../scripts/target_post.cmake)

--- a/src/FluidStats/FluidStats.cpp
+++ b/src/FluidStats/FluidStats.cpp
@@ -1,0 +1,22 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#include <clients/rt/RunningStatsClient.hpp>
+
+#include <FluidSCWrapper.hpp>
+
+static InterfaceTable *ft;
+
+PluginLoad(FluidStatsUGen)
+{
+  ft = inTable;
+  using namespace fluid::client;
+  makeSCWrapper<RunningStatsClient>("FluidStats", ft);
+}


### PR DESCRIPTION
Support for this PR https://github.com/flucoma/flucoma-core/pull/35

Most of the work here is in updating the SC class files to use the new, explicit plugins instead of relying on magic incantations. The user facing behaviour ought to be unchanged. In principle, I think they should be more robust when writing more generic `SynthDef`s. 

The `Fluid<X>Query` UGen classes perhaps warrant documentation than they did before, but I haven't done that yet.