### PR TITLE
Nightly Builds and Continuous Integration

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,10 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: setup environment
-        uses: flucoma/actions/env@v1 
-
-      - name: install ninja
-        run: brew install ninja
+        uses: flucoma/actions/env@v2
 
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
@@ -46,10 +43,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: setup environment
-        uses: flucoma/actions/env@v1 
-
-      - name: install ninja
-        run: choco install ninja
+        uses: flucoma/actions/env@v2
 
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk 
@@ -80,10 +74,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: setup environment
-        uses: flucoma/actions/env@v1
-
-      - name: install ninja
-        run: sudo apt-get install ninja-build
+        uses: flucoma/actions/env@v2
 
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -28,7 +28,7 @@ jobs:
         working-directory: build
         
       - name: install
-        run: ninja FluidAmpSlice
+        run: ninja install
         working-directory: build
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
@@ -53,7 +53,7 @@ jobs:
         working-directory: build
         
       - name: install
-        run: cmake --build . --target FluidAmpSlice
+        run: cmake --build . --target install
         working-directory: build
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
@@ -78,7 +78,7 @@ jobs:
         working-directory: build
         
       - name: install
-        run: make FluidAmpSlice
+        run: make install
         working-directory: build
       
       - uses: actions/upload-artifact@v2                                                                                                                                                 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,7 +2,7 @@ name: Nightly Releases
 
 on:
   push:
-    branches: [ main, ci/automatic-building ]
+    branches: [ main, ci/nightlies ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,7 +7,6 @@ on:
     branches: [ dev ]
 
 jobs:
-  # Eventually this https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895/5
   macbuild:
     runs-on: macos-11
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -132,8 +132,13 @@ jobs:
           name: linuxbuild
           path: .
       
-      - name: see
-        run: ls -R
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true # default: false
+          tag_name: 1.0.0-nightly # tag name to delete
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
         
       - name: package and upload
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -98,7 +98,7 @@ jobs:
         run: mkdir build
         
       - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core    
+        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core    
 
       - name: cmake
         run: cmake -DSC_PATH=../sdk -DFLUID_PATH=../core ..
@@ -144,7 +144,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        
       - name: package and upload
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,8 +7,6 @@ on:
     branches: [ dev ]
 
 jobs:
-  env: 
-    CMAKE_CMD: cmake -GNinja -DSC_PATH=../sdk -DFLUID_PATH=../core ..
   macbuild:
     runs-on: macos-11
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,7 +44,7 @@ jobs:
         run: mkdir build
         
       - name: cmake
-        run: cmake -GNinja -DSC_PATH="../sdk" ..
+        run: cmake -DSC_PATH="../sdk" ..
         working-directory: build
         
       - name: install
@@ -64,7 +64,7 @@ jobs:
         run: mkdir build
         
       - name: cmake
-        run: cmake -GNinja -DSC_PATH=../sdk ..
+        run: cmake -DSC_PATH=../sdk ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -26,7 +26,7 @@ jobs:
         run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core     
         
       - name: cmake
-        run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_CORE=../core ..
+        run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_PATH=../core ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install ninja
+        run: brew install ninja
+
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
         
@@ -19,11 +22,11 @@ jobs:
         run: mkdir -p build
         
       - name: cmake
-        run: cmake -DSC_PATH=../sdk ..
+        run: cmake -GNinja -DSC_PATH=../sdk ..
         working-directory: build
         
       - name: install
-        run: make install -j$(sysctl -n hw.ncpu)
+        run: ninja install
         working-directory: build
 
       - name: zip release
@@ -52,7 +55,7 @@ jobs:
         working-directory: build
         
       - name: install
-        run: cmake --build . --target install
+        run: cmake --build . --target install --config Release
         working-directory: build
 
       - name: remove pdb files
@@ -71,6 +74,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: install ninja
+        run: apt-get install ninja-build
 
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,7 +27,8 @@ jobs:
         working-directory: build
 
       - name: zip release
-        run: zip -r FluCoMa-SC-Mac-nightly.zip install/FluidCorpusManipulation
+        run: zip -r ../FluCoMa-SC-Mac-nightly.zip FluidCorpusManipulation
+        working-directory: install
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
@@ -86,7 +87,8 @@ jobs:
         working-directory: build
 
       - name: zip release
-        run: zip -r FluCoMa-SC-Linux-nightly.zip install/FluidCorpusManipulation
+        run: zip -r ../FluCoMa-SC-Linux-nightly.zip FluidCorpusManipulation
+        working-directory: install
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
@@ -112,6 +114,9 @@ jobs:
         with:
           name: linuxbuild
           path: FluCoMa-SC-Linux-nightly.zip
+      
+      - name: see
+        run: ls -R
         
       - name: package and upload
         uses: svenstaro/upload-release-action@v2
@@ -122,5 +127,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: FluCoMa-SC-*.zip
           file_glob: true
-          tag: nightly
+          tag: 1.0.0-nightly
           overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,6 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install ninja
+        run: choco install ninja
+
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
         

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -70,6 +70,7 @@ jobs:
 
       - name: install
         run: ninja install
+        working-directory: build
 
       - name: remove pdb files
         run: Remove-Item install -Recurse -Include *.pdb

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install ninja
-        run: apt-get install ninja-build
+        run: sudo apt-get install ninja-build
 
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,10 +31,10 @@ jobs:
         run: ninja FluidAmpSlice
         working-directory: build
 
-     - uses: actions/upload-artifact@v2                                                                                                                                                 
-       with:                                                                                                                                                                            
-         name: macbuild                                                                                                                                                                 
-         path: release-packaging/
+      - uses: actions/upload-artifact@v2                                                                                                                                                 
+        with:                                                                                                                                                                            
+          name: macbuild                                                                                                                                                                 
+          path: release-packaging/
 
   winbuild:
     runs-on: windows-latest
@@ -88,6 +88,7 @@ jobs:
   
   release:
     runs-on: ubuntu-latest
+    needs: [macbuild, winbuild, linuxbuild]
 
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,12 +18,14 @@ jobs:
 
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
-        
-      - name: make build directory
-        run: mkdir -p build
 
-      - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core     
+      - name: setup environment
+        uses: flucoma/actions/env/action.yaml@v1        
+      # - name: make build directory
+      #   run: mkdir -p build
+
+      # - name: clone latest flucoma-core
+      #   run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core     
         
       - name: cmake
         run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_PATH=../core ..

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,6 +7,8 @@ on:
     branches: [ dev ]
 
 jobs:
+  env: 
+    CMAKE_CMD: cmake -GNinja -DSC_PATH=../sdk -DFLUID_PATH=../core ..
   macbuild:
     runs-on: macos-11
 
@@ -20,7 +22,7 @@ jobs:
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
 
       - name: cmake
-        run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_PATH=../core ..
+        run: ${{ env.CMAKE_CMD }}
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,7 +23,7 @@ jobs:
         working-directory: build
         
       - name: install
-        run: make install -j8
+        run: make install -j$(sysctl -n hw.ncpu)
         working-directory: build
 
       - name: zip release

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,9 +16,6 @@ jobs:
       - name: setup environment
         uses: flucoma/actions/env@v2
 
-      - name: get supercollider source
-        run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
-
       - name: build toolkit
         uses: flucoma/actions/scbuild@v2
 
@@ -40,16 +37,8 @@ jobs:
       - name: setup environment
         uses: flucoma/actions/env@v2
 
-      - name: get supercollider source
-        run: git clone --recursive https://github.com/supercollider/supercollider.git sdk 
-        
-      - name: cmake
-        run: cmake -GNinja -DSC_PATH="../sdk" -DFLUID_PATH="../core" ..
-        working-directory: build
-
-      - name: install
-        run: ninja install
-        working-directory: build
+      - name: build toolkit
+        uses: flucoma/actions/scbuild@v2
 
       - name: remove pdb files
         run: Remove-Item install -Recurse -Include *.pdb
@@ -71,16 +60,8 @@ jobs:
       - name: setup environment
         uses: flucoma/actions/env@v2
 
-      - name: get supercollider source
-        run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
-
-      - name: cmake
-        run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_PATH=../core ..
-        working-directory: build
-        
-      - name: install
-        run: ninja install
-        working-directory: build
+      - name: build toolkit
+        uses: flucoma/actions/scbuild@v2
 
       - name: zip release
         run: zip -r ../FluCoMa-SC-Linux-nightly.zip FluidCorpusManipulation

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -121,9 +121,9 @@ jobs:
       - name: package and upload
         uses: svenstaro/upload-release-action@v2
         with:
-          release_name: FluCoMa Max Nightly Build
+          release_name: FluCoMa SuperCollider Nightly Build
           prerelease: true
-          body: "This is a nightly build of the FluCoMa Max package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
+          body: "This is a nightly build of the FluCoMa SuperCollider package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: FluCoMa-SC-*.zip
           file_glob: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install ninja
-        run: brew install ninja
-
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
         
@@ -22,17 +19,20 @@ jobs:
         run: mkdir -p build
         
       - name: cmake
-        run: cmake -GNinja -DSC_PATH=../sdk ..
+        run: cmake -DSC_PATH=../sdk ..
         working-directory: build
         
       - name: install
-        run: ninja install
+        run: make install -j8
         working-directory: build
+
+      - name: zip release
+        run: zip -r FluCoMa-SC-Mac-nightly.zip install/FluidCorpusManipulation
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
           name: macbuild                                                                                                                                                                 
-          path: release-packaging/
+          path: FluCoMa-SC-Mac-nightly.zip
 
   winbuild:
     runs-on: windows-latest
@@ -55,12 +55,15 @@ jobs:
         working-directory: build
 
       - name: remove pdb files
-        run: Remove-Item release-packaging -Recurse -Include *.pdb
+        run: Remove-Item install -Recurse -Include *.pdb
+
+      - name: zip release
+        run: zip -r FluCoMa-SC-Windows-nightly.zip install/FluidCorpusManipulation
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
-          name: winbuild                                                                                                                                                              
-          path: release-packaging/
+          name: winbuild                                                                                                                                                                
+          path: FluCoMa-SC-Windows-nightly.zip
 
   linuxbuild:
     runs-on: ubuntu-18.04
@@ -79,13 +82,16 @@ jobs:
         working-directory: build
         
       - name: install
-        run: make install
+        run: make install -j$(nproc)
         working-directory: build
-      
+
+      - name: zip release
+        run: zip -r FluCoMa-SC-Linux-nightly.zip install/FluidCorpusManipulation
+
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
-          name: linuxbuild                                                                                                                                                            
-          path: release-packaging/
+          name: linuxbuild                                                                                                                                                                
+          path: FluCoMa-SC-Linux-nightly.zip
   
   release:
     runs-on: ubuntu-latest
@@ -95,26 +101,17 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: macbuild
-          path: FluCoMa-SC-Mac-nightly
+          path: FluCoMa-SC-Mac-nightly.zip
       
       - uses: actions/download-artifact@v2
         with:
           name: winbuild
-          path: FluCoMa-SC-Windows-nightly
+          path: FluCoMa-SC-Windows-nightly.zip
 
       - uses: actions/download-artifact@v2
         with:
           name: linuxbuild
-          path: FluCoMa-SC-Linux-nightly
-      
-      - name: zip mac
-        run: zip -r FluCoMa-SC-Mac-nightly.zip FluCoMa-SC-Mac-nightly
-      
-      - name: zip win
-        run: zip -r FluCoMa-SC-Windows-nightly.zip FluCoMa-SC-Windows-nightly
-
-      - name: zip linux
-        run: zip -r FluCoMa-SC-Linux-nightly.zip FluCoMa-SC-Linux-nightly
+          path: FluCoMa-SC-Linux-nightly.zip
         
       - name: package and upload
         uses: svenstaro/upload-release-action@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,6 +3,8 @@ name: Nightly Releases
 on:
   push:
     branches: [ dev, ci/nightlies ]
+  pull_request:
+    branches: [ dev ]
 
 jobs:
   # Eventually this https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895/5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -106,21 +106,23 @@ jobs:
           name: linuxbuild
           path: FluCoMa-SC-Linux-nightly
       
-      - name: see
-        run: ls -R
+      - name: zip mac
+        run: zip -r FluCoMa-SC-Mac-nightly.zip FluCoMa-SC-Mac-nightly
       
-    # - name: zip release
-    #   run: zip -r release.zip externals
-      
-    # - name: package and upload
-    #   uses: svenstaro/upload-release-action@v2
-    #   with:
-    #     release_name: FluCoMa Max Nightly Build
-    #     prerelease: true
-    #     body: "This is a nightly build of the FluCoMa Max package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
-    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
-    #     file: release.zip
-    #     asset_name: FluCoMa-Max-nightly.zip
-    #     tag: nightly
-    #     overwrite: true
+      - name: zip win
+        run: zip -r FluCoMa-SC-Windows-nightly.zip FluCoMa-SC-Windows-nightly
+
+      - name: zip linux
+        run: zip -r FluCoMa-SC-Linux-nightly.zip FluCoMa-SC-Linux-nightly
         
+      - name: package and upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          release_name: FluCoMa Max Nightly Build
+          prerelease: true
+          body: "This is a nightly build of the FluCoMa Max package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: FluCoMa-SC-*.zip
+          file_glob: true
+          tag: nightly
+          overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,9 +2,7 @@ name: Nightly Releases
 
 on:
   push:
-    branches: [ main, ci/nightlies ]
-  pull_request:
-    branches: [ main ]
+    branches: [ dev, ci/nightlies ]
 
 jobs:
   # Eventually this https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895/5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,15 +58,18 @@ jobs:
         run: mkdir build
 
       - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
+        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core   
         
       - name: cmake
         run: cmake -DSC_PATH="../sdk" -DFLUID_PATH="../core" ..
         working-directory: build
         
+      # - name: install
+      #   run: cmake --build . --target install --config Release
+      #   working-directory: build
+
       - name: install
-        run: cmake --build . --target install --config Release
-        working-directory: build
+        run: ninja install
 
       - name: remove pdb files
         run: Remove-Item install -Recurse -Include *.pdb

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -23,7 +23,7 @@ jobs:
         run: mkdir -p build
 
       - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core     
+        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core     
         
       - name: cmake
         run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_CORE=../core ..

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,7 +20,7 @@ jobs:
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
 
       - name: setup environment
-        uses: flucoma/actions/env/action.yaml@v1        
+        uses: flucoma/actions/env@v1        
       # - name: make build directory
       #   run: mkdir -p build
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,9 +22,12 @@ jobs:
         
       - name: make build directory
         run: mkdir -p build
+
+      - name: clone latest flucoma-core
+        run: git clone --branch dev git@github.com:flucoma/flucoma-core.git core     
         
       - name: cmake
-        run: cmake -GNinja -DSC_PATH=../sdk ..
+        run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_CORE=../core ..
         working-directory: build
         
       - name: install
@@ -51,9 +54,12 @@ jobs:
         
       - name: make build directory
         run: mkdir build
+
+      - name: clone latest flucoma-core
+        run: git clone --branch dev git@github.com:flucoma/flucoma-core.git core   
         
       - name: cmake
-        run: cmake -DSC_PATH="../sdk" ..
+        run: cmake -DSC_PATH="../sdk" -DFLUID_CORE="../core" ..
         working-directory: build
         
       - name: install
@@ -86,8 +92,11 @@ jobs:
       - name: make build directory
         run: mkdir build
         
+      - name: clone latest flucoma-core
+        run: git clone --branch dev git@github.com:flucoma/flucoma-core.git core    
+
       - name: cmake
-        run: cmake -DSC_PATH=../sdk ..
+        run: cmake -DSC_PATH=../sdk -DFLUID_CORE=../core ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,7 +58,7 @@ jobs:
         run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
         
       - name: cmake
-        run: cmake -DSC_PATH="../sdk" -DFLUID_CORE="../core" ..
+        run: cmake -DSC_PATH="../sdk" -DFLUID_PATH="../core" ..
         working-directory: build
         
       - name: install
@@ -95,7 +95,7 @@ jobs:
         run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core    
 
       - name: cmake
-        run: cmake -DSC_PATH=../sdk -DFLUID_CORE=../core ..
+        run: cmake -DSC_PATH=../sdk -DFLUID_PATH=../core ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,64 @@
+name: Nightly Releases
+
+on:
+  push:
+    branches: [ main, ci/automatic-building ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  
+  macbuild:
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install ninja
+        run: brew install ninja
+
+      - name: get supercollider source
+        run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
+        
+      - name: make build directory
+        run: mkdir -p build
+        
+      - name: cmake
+        run: cmake -GNinja -DSC_PATH=../sdk ..
+        working-directory: build
+        
+      - name: install
+        run: ninja FluidAmpSlice
+        working-directory: build
+      
+        
+    #   - name: zip release
+    #     run: zip -r release.zip externals
+        
+    #   - name: package and upload
+    #     uses: svenstaro/upload-release-action@v2
+    #     with:
+    #       release_name: FluCoMa Max Nightly Build
+    #       prerelease: true
+    #       body: "This is a nightly build of the FluCoMa Max package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
+    #       repo_token: ${{ secrets.GITHUB_TOKEN }}
+    #       file: release.zip
+    #       asset_name: FluCoMa-Max-nightly.zip
+    #       tag: nightly
+    #       overwrite: true
+      
+    # - name: zip release
+    #   run: zip -r release.zip externals
+      
+    # - name: package and upload
+    #   uses: svenstaro/upload-release-action@v2
+    #   with:
+    #     release_name: FluCoMa Max Nightly Build
+    #     prerelease: true
+    #     body: "This is a nightly build of the FluCoMa Max package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
+    #     repo_token: ${{ secrets.GITHUB_TOKEN }}
+    #     file: release.zip
+    #     asset_name: FluCoMa-Max-nightly.zip
+    #     tag: nightly
+    #     overwrite: true
+        

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,8 +57,7 @@ jobs:
         working-directory: build
 
       - name: remove pdb files
-        run: del /S *.pdb
-        working-directory: release-packaging
+        run: Remove-Item release-packaging -Recurse -Include *.pdb
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  
+  # Eventually this https://github.community/t/create-matrix-with-multiple-os-and-env-for-each-one/16895/5
   macbuild:
     runs-on: macos-11
 
@@ -30,22 +30,47 @@ jobs:
       - name: install
         run: ninja FluidAmpSlice
         working-directory: build
+
+    winbuild:
+      runs-on: windows-latest
+
+      steps:
+        - uses: actions/checkout@v2
+
+        - name: get supercollider source
+          run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
+          
+        - name: make build directory
+          run: mkdir build
+          
+        - name: cmake
+          run: cmake -GNinja -DSC_PATH="../sdk" ..
+          working-directory: build
+          
+        - name: install
+          run: cmake --build . --target FluidAmpSlice
+          working-directory: build
+  
+      linuxbuild:
+        runs-on: ubuntu-latest
+
+        steps:
+          - uses: actions/checkout@v2
+
+          - name: get supercollider source
+            run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
+            
+          - name: make build directory
+            run: mkdir build
+            
+          - name: cmake
+            run: cmake -GNinja -DSC_PATH=../sdk ..
+            working-directory: build
+            
+          - name: install
+            run: make FluidAmpSlice
+            working-directory: build
       
-        
-    #   - name: zip release
-    #     run: zip -r release.zip externals
-        
-    #   - name: package and upload
-    #     uses: svenstaro/upload-release-action@v2
-    #     with:
-    #       release_name: FluCoMa Max Nightly Build
-    #       prerelease: true
-    #       body: "This is a nightly build of the FluCoMa Max package. As such, be warned there may be bugs or other unexpected behaviour. The build hash is ${{ github.sha }}"
-    #       repo_token: ${{ secrets.GITHUB_TOKEN }}
-    #       file: release.zip
-    #       asset_name: FluCoMa-Max-nightly.zip
-    #       tag: nightly
-    #       overwrite: true
       
     # - name: zip release
     #   run: zip -r release.zip externals

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -99,7 +99,7 @@ jobs:
         working-directory: build
         
       - name: install
-        run: make install -j$(nproc)
+        run: ninja install
         working-directory: build
 
       - name: zip release
@@ -134,7 +134,7 @@ jobs:
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true # default: false
-          tag_name: 1.0.0-nightly # tag name to delete
+          tag_name: nightly # tag name to delete
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -148,5 +148,5 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: FluCoMa-SC-*.zip
           file_glob: true
-          tag: 1.0.0-nightly
+          tag: nightly
           overwrite: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,13 +21,8 @@ jobs:
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
 
-      - name: cmake
-        run: ${{ env.CMAKE_CMD }}
-        working-directory: build
-        
-      - name: install
-        run: ninja install
-        working-directory: build
+      - name: build toolkit
+        uses: flucoma/actions/scbuild@v2
 
       - name: zip release
         run: zip -r ../FluCoMa-SC-Mac-nightly.zip FluidCorpusManipulation

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,20 +13,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: setup environment
+        uses: flucoma/actions/env@v1 
+
       - name: install ninja
         run: brew install ninja
 
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
 
-      - name: setup environment
-        uses: flucoma/actions/env@v1        
-      # - name: make build directory
-      #   run: mkdir -p build
-
-      # - name: clone latest flucoma-core
-      #   run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core     
-        
       - name: cmake
         run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_PATH=../core ..
         working-directory: build
@@ -50,25 +45,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: setup environment
+        uses: flucoma/actions/env@v1 
+
       - name: install ninja
         run: choco install ninja
 
       - name: get supercollider source
-        run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
-        
-      - name: make build directory
-        run: mkdir build
-
-      - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core   
+        run: git clone --recursive https://github.com/supercollider/supercollider.git sdk 
         
       - name: cmake
-        run: cmake -DSC_PATH="../sdk" -DFLUID_PATH="../core" ..
+        run: cmake -GNinja -DSC_PATH="../sdk" -DFLUID_PATH="../core" ..
         working-directory: build
-        
-      # - name: install
-      #   run: cmake --build . --target install --config Release
-      #   working-directory: build
 
       - name: install
         run: ninja install
@@ -91,20 +79,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: setup environment
+        uses: flucoma/actions/env@v1
+
       - name: install ninja
         run: sudo apt-get install ninja-build
 
       - name: get supercollider source
         run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
-        
-      - name: make build directory
-        run: mkdir build
-        
-      - name: clone latest flucoma-core
-        run: git clone --branch dev https://github.com/flucoma/flucoma-core.git core    
 
       - name: cmake
-        run: cmake -DSC_PATH=../sdk -DFLUID_PATH=../core ..
+        run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_PATH=../core ..
         working-directory: build
         
       - name: install

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -65,7 +65,7 @@ jobs:
           path: release-packaging/
 
   linuxbuild:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -103,17 +103,17 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: macbuild
-          path: FluCoMa-SC-Mac-nightly.zip
+          path: .
       
       - uses: actions/download-artifact@v2
         with:
           name: winbuild
-          path: FluCoMa-SC-Windows-nightly.zip
+          path: .
 
       - uses: actions/download-artifact@v2
         with:
           name: linuxbuild
-          path: FluCoMa-SC-Linux-nightly.zip
+          path: .
       
       - name: see
         run: ls -R

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,6 +31,11 @@ jobs:
         run: ninja FluidAmpSlice
         working-directory: build
 
+     - uses: actions/upload-artifact@v2                                                                                                                                                 
+       with:                                                                                                                                                                            
+         name: macbuild                                                                                                                                                                 
+         path: release-packaging/
+
   winbuild:
     runs-on: windows-latest
 
@@ -50,6 +55,11 @@ jobs:
       - name: install
         run: cmake --build . --target FluidAmpSlice
         working-directory: build
+
+      - uses: actions/upload-artifact@v2                                                                                                                                                 
+        with:                                                                                                                                                                            
+          name: winbuild                                                                                                                                                              
+          path: release-packaging/
 
   linuxbuild:
     runs-on: ubuntu-latest
@@ -71,6 +81,32 @@ jobs:
         run: make FluidAmpSlice
         working-directory: build
       
+      - uses: actions/upload-artifact@v2                                                                                                                                                 
+        with:                                                                                                                                                                            
+          name: linuxbuild                                                                                                                                                            
+          path: release-packaging/
+  
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: macbuild
+          path: FluCoMa-SC-Mac-nightly
+      
+      - uses: actions/download-artifact@v2
+        with:
+          name: winbuild
+          path: FluCoMa-SC-Windows-nightly
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: linuxbuild
+          path: FluCoMa-SC-Linux-nightly
+      
+      - name: see
+        run: ls -R
       
     # - name: zip release
     #   run: zip -r release.zip externals

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: flucoma/actions/env@v2
 
       - name: build toolkit
-        uses: flucoma/actions/scbuild@v2
+        uses: flucoma/actions/sc@v2
 
       - name: zip release
         run: zip -r ../FluCoMa-SC-Mac-nightly.zip FluidCorpusManipulation
@@ -38,7 +38,7 @@ jobs:
         uses: flucoma/actions/env@v2
 
       - name: build toolkit
-        uses: flucoma/actions/scbuild@v2
+        uses: flucoma/actions/sc@v2
 
       - name: remove pdb files
         run: Remove-Item install -Recurse -Include *.pdb
@@ -61,7 +61,7 @@ jobs:
         uses: flucoma/actions/env@v2
 
       - name: build toolkit
-        uses: flucoma/actions/scbuild@v2
+        uses: flucoma/actions/sc@v2
 
       - name: zip release
         run: zip -r ../FluCoMa-SC-Linux-nightly.zip FluidCorpusManipulation

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -24,7 +24,7 @@ jobs:
         run: mkdir -p build
 
       - name: clone latest flucoma-core
-        run: git clone --branch dev git@github.com:flucoma/flucoma-core.git core     
+        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core     
         
       - name: cmake
         run: cmake -GNinja -DSC_PATH=../sdk -DFLUID_CORE=../core ..
@@ -56,7 +56,7 @@ jobs:
         run: mkdir build
 
       - name: clone latest flucoma-core
-        run: git clone --branch dev git@github.com:flucoma/flucoma-core.git core   
+        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core   
         
       - name: cmake
         run: cmake -DSC_PATH="../sdk" -DFLUID_CORE="../core" ..
@@ -93,7 +93,7 @@ jobs:
         run: mkdir build
         
       - name: clone latest flucoma-core
-        run: git clone --branch dev git@github.com:flucoma/flucoma-core.git core    
+        run: git clone --branch dev https://github.com/flucoma/flucoma-sc.git core    
 
       - name: cmake
         run: cmake -DSC_PATH=../sdk -DFLUID_CORE=../core ..

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,7 +58,7 @@ jobs:
         run: Remove-Item install -Recurse -Include *.pdb
 
       - name: zip release
-        run: zip -r FluCoMa-SC-Windows-nightly.zip install/FluidCorpusManipulation
+        run: Compress-Archive install/FluidCorpusManipulation FluCoMa-SC-Windows-nightly.zip
 
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,45 +31,45 @@ jobs:
         run: ninja FluidAmpSlice
         working-directory: build
 
-    winbuild:
-      runs-on: windows-latest
+  winbuild:
+    runs-on: windows-latest
 
-      steps:
-        - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-        - name: get supercollider source
-          run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
-          
-        - name: make build directory
-          run: mkdir build
-          
-        - name: cmake
-          run: cmake -GNinja -DSC_PATH="../sdk" ..
-          working-directory: build
-          
-        - name: install
-          run: cmake --build . --target FluidAmpSlice
-          working-directory: build
-  
-      linuxbuild:
-        runs-on: ubuntu-latest
+      - name: get supercollider source
+        run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
+        
+      - name: make build directory
+        run: mkdir build
+        
+      - name: cmake
+        run: cmake -GNinja -DSC_PATH="../sdk" ..
+        working-directory: build
+        
+      - name: install
+        run: cmake --build . --target FluidAmpSlice
+        working-directory: build
 
-        steps:
-          - uses: actions/checkout@v2
+  linuxbuild:
+    runs-on: ubuntu-latest
 
-          - name: get supercollider source
-            run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
-            
-          - name: make build directory
-            run: mkdir build
-            
-          - name: cmake
-            run: cmake -GNinja -DSC_PATH=../sdk ..
-            working-directory: build
-            
-          - name: install
-            run: make FluidAmpSlice
-            working-directory: build
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: get supercollider source
+        run: git clone --recursive https://github.com/supercollider/supercollider.git sdk
+        
+      - name: make build directory
+        run: mkdir build
+        
+      - name: cmake
+        run: cmake -GNinja -DSC_PATH=../sdk ..
+        working-directory: build
+        
+      - name: install
+        run: make FluidAmpSlice
+        working-directory: build
       
       
     # - name: zip release

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -56,6 +56,10 @@ jobs:
         run: cmake --build . --target install
         working-directory: build
 
+      - name: remove pdb files
+        run: del /S *.pdb
+        working-directory: release-packaging
+
       - uses: actions/upload-artifact@v2                                                                                                                                                 
         with:                                                                                                                                                                            
           name: winbuild                                                                                                                                                              

--- a/src/FluidBufNNDSVD/CMakeLists.txt
+++ b/src/FluidBufNNDSVD/CMakeLists.txt
@@ -12,6 +12,10 @@ get_filename_component(PLUGIN ${CMAKE_CURRENT_LIST_DIR} NAME_WE)
 message("Configuring ${PLUGIN}")
 set(FILENAME ${PLUGIN}.cpp)
 
+if(WIN32)
+  target_compile_options(${PLUGIN} PUBLIC /bigobj)   
+endif()
+
 add_library(
   ${PLUGIN}
   MODULE

--- a/src/FluidBufNNDSVD/CMakeLists.txt
+++ b/src/FluidBufNNDSVD/CMakeLists.txt
@@ -12,10 +12,6 @@ get_filename_component(PLUGIN ${CMAKE_CURRENT_LIST_DIR} NAME_WE)
 message("Configuring ${PLUGIN}")
 set(FILENAME ${PLUGIN}.cpp)
 
-if(WIN32)
-  target_compile_options(${PLUGIN} PUBLIC /bigobj)   
-endif()
-
 add_library(
   ${PLUGIN}
   MODULE

--- a/src/FluidBufNNDSVD/CMakeLists.txt
+++ b/src/FluidBufNNDSVD/CMakeLists.txt
@@ -12,10 +12,6 @@ get_filename_component(PLUGIN ${CMAKE_CURRENT_LIST_DIR} NAME_WE)
 message("Configuring ${PLUGIN}")
 set(FILENAME ${PLUGIN}.cpp)
 
-if(WIN32)
-  target_compile_options(${PLUGIN} PUBLIC /bigobj)   
-endif()
-
 add_library(
   ${PLUGIN}
   MODULE
@@ -23,3 +19,7 @@ add_library(
 )
 
 include(${CMAKE_CURRENT_LIST_DIR}/../../scripts/target_post.cmake)
+
+if(WIN32)
+  target_compile_options(${PLUGIN} PUBLIC /bigobj)   
+endif()

--- a/src/FluidBufNNDSVD/CMakeLists.txt
+++ b/src/FluidBufNNDSVD/CMakeLists.txt
@@ -12,6 +12,10 @@ get_filename_component(PLUGIN ${CMAKE_CURRENT_LIST_DIR} NAME_WE)
 message("Configuring ${PLUGIN}")
 set(FILENAME ${PLUGIN}.cpp)
 
+if(WIN32)
+  target_compile_options(${PLUGIN} PUBLIC /bigobj)   
+endif()
+
 add_library(
   ${PLUGIN}
   MODULE
@@ -19,7 +23,3 @@ add_library(
 )
 
 include(${CMAKE_CURRENT_LIST_DIR}/../../scripts/target_post.cmake)
-
-if(WIN32)
-  target_compile_options(${PLUGIN} PUBLIC /bigobj)   
-endif()


### PR DESCRIPTION
This PR adds a github workflow to generate nightly builds of the FluCoMa tools. This introduces a way of thinking about our approach to github and the treatment of branches and pull requests. So:

1. I've created a `dev` branch. All work that is not tested or stable should be worked on as _branches_ from this branch and _not_ `main`. `Main` is reserved for stable code and releases, `dev` is for iteration and pull requests. We merge to `main` when we have enough changes that constitute a formal release.
2. All commits or pull requests to `dev` now trigger the automatic creation of nightly builds which exist in a tagged release. The tag is still up for debate naturally but is easy enough to change.

This is an example output of the integration at work: https://github.com/jamesb93/flucoma-sc/releases/tag/1.0.0-nightly

That's about it :)