### PR TITLE
Buf to kr enhancements

### DIFF
--- a/release-packaging/Classes/FluidBufToKr.sc
+++ b/release-packaging/Classes/FluidBufToKr.sc
@@ -1,9 +1,15 @@
 FluidKrToBuf {
 	*kr {
 		arg krStream, buffer;
-		if(buffer.numFrames == 0) {"FluidKrToBuf: UGen will have 0 outputs!".warn};
-		if(buffer.numFrames > 1000) {"FluidKrToBuf: Buffer is % frames. This is probably not the buffer you intended.".format(buffer.numFrames).error};
-		^buffer.numFrames.do{
+
+		if(buffer.isKindOf(Buffer).or(buffer.isKindOf(LocalBuf)),{
+			if(buffer.numFrames == 0) {"FluidKrToBuf:kr Buffer has 0 frames".warn};
+			if(buffer.numFrames > 1000) {
+				Error("FluidKrToBuf:kr Buffer is % frames. This is probably not the buffer you intended.".format(buffer.numFrames)).throw;
+			};
+		});
+
+		^krStream.numChannels.do{
 			arg i;
 			BufWr.kr(krStream[i], buffer, i);
 		}
@@ -12,12 +18,21 @@ FluidKrToBuf {
 
 FluidBufToKr {
 	*kr {
-		arg buffer;
-		if(buffer.numFrames == 0) {"FluidKrToBuf: Buffer has 0 frames!".warn};
-		if(buffer.numFrames > 1000) {"FluidKrToBuf: Buffer is % frames. This is probably not the buffer you intended.".format(buffer.numFrames).error};
+		arg buffer, numFrames;
 
-		if(buffer.numFrames > 1,{
-			^buffer.numFrames.collect{
+		if((buffer.isKindOf(Buffer).or(buffer.isKindOf(LocalBuf))).not.and(numFrames.isNil),{
+			Error("FluidBufToKr:kr needs to be passed either an existing buffer or an OutputProxy and a number of frames for the buffer that will be supplied").throw;
+		});
+
+		numFrames = numFrames ?? {buffer.numFrames};
+
+		if(numFrames == 0) {"FluidKrToBuf:kr indicated numFrames is zero.".warn};
+		if(numFrames > 1000) {
+			Error("FluidKrToBuf: Buffer is indicated to have % frames. This is probably not the buffer you intended.".format(numFrames)).throw;
+		};
+
+		if(numFrames > 1,{
+			^numFrames.collect{
 				arg i;
 				BufRd.kr(1,buffer,i,0,0);
 			}

--- a/release-packaging/Classes/FluidBufToKr.sc
+++ b/release-packaging/Classes/FluidBufToKr.sc
@@ -18,13 +18,15 @@ FluidKrToBuf {
 
 FluidBufToKr {
 	*kr {
-		arg buffer, numFrames;
+		arg buffer, numFrames = -1;
 
 		if((buffer.isKindOf(Buffer).or(buffer.isKindOf(LocalBuf))).not.and(numFrames.isNil),{
 			Error("FluidBufToKr:kr needs to be passed either an existing buffer or an OutputProxy and a number of frames for the buffer that will be supplied").throw;
 		});
 
-		numFrames = numFrames ?? {buffer.numFrames};
+		if(numFrames == -1,{
+			numFrames = buffer.numFrames;
+		});
 
 		if(numFrames == 0) {"FluidKrToBuf:kr indicated numFrames is zero.".warn};
 		if(numFrames > 1000) {

--- a/release-packaging/HelpSource/Classes/FluidBufToKr.schelp
+++ b/release-packaging/HelpSource/Classes/FluidBufToKr.schelp
@@ -14,6 +14,9 @@ Initialize an instance of this pseudo UGen
 ARGUMENT:: buffer
 The link::Classes/Buffer:: that this pseudo UGen will read out of. Must be a one-channel buffer.
 
+ARGUMENT:: numFrames
+How many frames the buffer is that will evenutally passed. If providing a buffer directly (instead of as an argument to a SynthDef), the default of -1 will get the number of frames from the buffer passed.
+
 returns:: a Kr stream that has the same number of channels as frames in the link::Classes/Buffer::.
 
 INSTANCEMETHODS::
@@ -21,19 +24,37 @@ INSTANCEMETHODS::
 EXAMPLES::
 
 code::
+// make a buffer with some data in it
+~buf = Buffer.loadCollection(s,[0,1,2,3,4,7]);
+
+// play it on the server and read out of this buffer!
 (
-// FluidBufToKr
-s.waitForBoot{
-	Routine{
-		var buf = Buffer.loadCollection(s,[0,1,2,3,4,7]);
-
-		s.sync;
-
-		{
-			var sig = FluidBufToKr.kr(buf);
-			sig.poll;
-		}.play;
-	}.play;
-}
+{
+	var sig = FluidBufToKr.kr(~buf);
+	sig.poll;
+}.play;
 )
+
+// =============== passing a buffer as an argument ======================
+
+// create a synth that both writes into a buffer (with FluidKrToBuf) and reads
+// out of the same buffer (with FluidBufToKr)
+(
+~synth = {
+	arg buf = 999;
+	FluidKrToBuf.kr(SinOsc.kr(Array.fill(5,{rrand(0.0,1.0)})),buf);
+
+	// you need to specify the 5 so the synth here will know how many channels to make
+	// the output proxy
+	FluidBufToKr.kr(buf,5).poll;
+}.play;
+// you should see all zeros! (unless your buffer #999 has something in it already!)
+)
+
+// ...then after it is running, instantiate the buffer
+~buffer = Buffer.alloc(s,5);
+
+// ...then send it to the buffer
+~synth.set(\buf,~buffer);
+// you should be able to see the sine oscillators now!
 ::

--- a/test/FluidBufToKr test.scd
+++ b/test/FluidBufToKr test.scd
@@ -64,7 +64,7 @@ s.waitForBoot{
 			FluidKrToBuf.kr(sig,buf);
 		}.play;
 
-		3.wait;
+		1.wait;
 
 		defer{buf.plot};
 	}.play;
@@ -85,7 +85,7 @@ s.waitForBoot{
 			FluidKrToBuf.kr(sig,buf);
 		}.play;
 
-		3.wait;
+		1.wait;
 
 		defer{buf.plot};
 	}.play;
@@ -137,7 +137,7 @@ s.waitForBoot{
 		s.sync;
 
 		{
-			var sig = SinOsc.kr(rrand(1.0.dup(buf.numFrames),4.0));
+			var sig = SinOsc.kr(rrand(1.0.dup(10),4.0));
 			FluidKrToBuf.kr(sig,buf);
 		}.play;
 
@@ -177,7 +177,7 @@ s.waitForBoot{
 			arg buf;
 			FluidKrToBuf.kr(SinOsc.kr(Array.fill(5,{rrand(0.0,1.0)})),buf);
 
-			FluidBufToKr.kr(buf).poll;
+			FluidBufToKr.kr(buf).poll; ///////// this will now throw an error asking for a numFrames
 		}.play;
 
 		2.wait;
@@ -194,10 +194,10 @@ s.waitForBoot{
 s.waitForBoot{
 	Routine{
 		~synth = {
-			arg buf;
+			arg buf = 999;
 			FluidKrToBuf.kr(SinOsc.kr(Array.fill(5,{rrand(0.0,1.0)})),buf);
 
-			FluidBufToKr.kr(buf,5).poll;
+			FluidBufToKr.kr(buf,5).poll; ////////// this will work becaues it knows how many frames the buffer will be
 		}.play;
 
 		2.wait;

--- a/test/FluidBufToKr test.scd
+++ b/test/FluidBufToKr test.scd
@@ -94,8 +94,7 @@ s.waitForBoot{
 
 (
 // FluidBufToKr
-// 100 is fine
-/// 1000 is fine
+
 s.waitForBoot{
 	Routine{
 		var buf = Buffer.loadCollection(s,Array.fill(1001,{arg i; i}));
@@ -112,8 +111,7 @@ s.waitForBoot{
 
 (
 // FluidBufToKr
-// 100 is fine
-/// 1000 is fine
+// This should throw an error because this sound file buffer is longer than 1000 samples
 s.waitForBoot{
 	Routine{
 		var buf = Buffer.read(s,"/Users/macprocomputer/Desktop/_flucoma/code/flucoma-core-src/AudioFiles/Harker-DS-TenOboeMultiphonics-M.wav");
@@ -130,8 +128,7 @@ s.waitForBoot{
 
 (
 // FluidKrToBuf test with super long buffer
-// 100 is fine
-// 1000 is fine
+// This should throw an error because this sound file buffer is longer than 1000 samples
 s.waitForBoot{
 	Routine{
 		// var buf = Buffer.alloc(s,1000);
@@ -151,3 +148,63 @@ s.waitForBoot{
 }
 )
 
+// ===================== pass a buffer to a running synth =======================
+(
+s.waitForBoot{
+	Routine{
+		~synth = {
+			arg buf;
+			FluidBufToKr.kr(buf,5).poll;
+		}.play;
+
+		2.wait;
+
+		"make buffer".postln;
+		~buffer = Buffer.alloc(s,5);
+		s.sync;
+		~buffer.setn(0,Array.fill(5,{rrand(0,100)}));
+		s.sync;
+		~synth.set(\buf,~buffer);
+	}.play;
+};
+)
+
+(
+// throws error because number of frames not specified
+s.waitForBoot{
+	Routine{
+		~synth = {
+			arg buf;
+			FluidKrToBuf.kr(SinOsc.kr(Array.fill(5,{rrand(0.0,1.0)})),buf);
+
+			FluidBufToKr.kr(buf).poll;
+		}.play;
+
+		2.wait;
+
+		~buffer = Buffer.alloc(s,5);
+		s.sync;
+		~synth.set(\buf,~buffer);
+	}.play;
+};
+)
+
+(
+// works
+s.waitForBoot{
+	Routine{
+		~synth = {
+			arg buf;
+			FluidKrToBuf.kr(SinOsc.kr(Array.fill(5,{rrand(0.0,1.0)})),buf);
+
+			FluidBufToKr.kr(buf,5).poll;
+		}.play;
+
+		2.wait;
+
+		~buffer = Buffer.alloc(s,5);
+		s.sync;
+		~synth.set(\buf,~buffer);
+	}.play;
+};
+)


### PR DESCRIPTION
From Issue #28 , added an optional argument to FluidBufToKr so that it can be initialized inside a SynthDef. This requires that a `numFrames` argument be supplied with the number of frames long that the buffer will be once supplied as an argument to a running synth.

Test code (with fixed version of `FluidBufToKr`):
```
(
// throws error because number of frames not specified
s.waitForBoot{
	Routine{
		~synth = {
			arg buf;
			FluidKrToBuf.kr(SinOsc.kr(Array.fill(5,{rrand(0.0,1.0)})),buf);

			FluidBufToKr.kr(buf).poll; ///////// this will now throw an error asking for a numFrames
		}.play;

		2.wait;

		~buffer = Buffer.alloc(s,5);
		s.sync;
		~synth.set(\buf,~buffer);
	}.play;
};
)

(
// works
s.waitForBoot{
	Routine{
		~synth = {
			arg buf;
			FluidKrToBuf.kr(SinOsc.kr(Array.fill(5,{rrand(0.0,1.0)})),buf);

			FluidBufToKr.kr(buf,5).poll; ////////// this will work becaues it knows how many frames the buffer will be
		}.play;

		2.wait;

		~buffer = Buffer.alloc(s,5);
		s.sync;
		~synth.set(\buf,~buffer);
	}.play;
};
)
``` 