### PR TITLE
[Enhance] Update resources folder structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ install(DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/
         DESTINATION ${SC_PACKAGE_ROOT}/Plugins
         PATTERN "*.ilk" EXCLUDE 
         PATTERN "*.PDB" EXCLUDE)
-install(DIRECTORY "${flucoma-core_SOURCE_DIR}/AudioFiles" 
+install(DIRECTORY "${flucoma-core_SOURCE_DIR}/Resources" 
         DESTINATION ${SC_PACKAGE_ROOT})
 install(FILES QuickStart.md 
         DESTINATION ${SC_PACKAGE_ROOT})

--- a/release-packaging/Classes/FluidFilesPath.sc
+++ b/release-packaging/Classes/FluidFilesPath.sc
@@ -2,6 +2,6 @@ FluidFilesPath {
 	*new {
 		arg fileName;
 		fileName = fileName ? "";
-		^("%/../AudioFiles/".format(File.realpath(FluidDataSet.class.filenameSymbol).dirname) +/+ fileName);
+		^("%/../Resources/AudioFiles/".format(File.realpath(FluidDataSet.class.filenameSymbol).dirname) +/+ fileName);
 	}
 }


### PR DESCRIPTION
This changes the way in which "Resources" (data, sound) are pulled from the core repository on build. This accomodates:

https://github.com/flucoma/flucoma-core/pull/88

Accompanying is a small update to FluidFilesPath, which will now return the Audio files with the additional level of directory. @tedmoore I'm not sure what this will break if paths are hard coded. I know you are going to pass through the help files and docs _anyway_ at some point, but perhaps this will need a quick go through to update the paths where its easy (such as loading a file using `SomeMassiveLine++"../AudioFiles/Nicol.wav` which would now be `SomeMassiveLine++"../Resources/AudioFiles/Nicol.wav`

- copy the whole resources folder from core
- make fluidfilespath respect the new structure
