### PR TITLE
Slicers: add enums for algorithm selection

### DIFF
--- a/release-packaging/Classes/FluidNoveltySlice.sc
+++ b/release-packaging/Classes/FluidNoveltySlice.sc
@@ -1,7 +1,15 @@
 FluidNoveltySlice : FluidRTUGen {
+
+	const <spectrum = 0;
+	const <mfcc = 1;
+	const <chroma = 2;
+	const <pitch = 3;
+	const <loudness = 4;
+
 	*ar { arg in = 0, algorithm = 0, kernelSize = 3, threshold = 0.8, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = 16384, maxKernelSize = 101, maxFilterSize = 100;
 		^this.multiNew('audio', in.asAudioRateInput(this), algorithm, kernelSize, threshold, filterSize, minSliceLength, windowSize, hopSize, fftSize, maxFFTSize, maxKernelSize, maxFilterSize)
 	}
+
 	checkInputs {
 		if(inputs.at(8).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");

--- a/release-packaging/Classes/FluidOnsetSlice.sc
+++ b/release-packaging/Classes/FluidOnsetSlice.sc
@@ -1,4 +1,16 @@
 FluidOnsetSlice : FluidRTUGen {
+
+	const <power = 0;
+	const <hfc = 1;
+	const <flux = 2;
+	const <mkl = 3;
+	const <is = 4;
+	const <cosine = 5;
+	const <phase = 6;
+	const <wphase = 7;
+	const <complex = 8;
+	const <rcomplex = 9;
+
 	*ar { arg in = 0, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = 16384;
 		^this.multiNew('audio', in.asAudioRateInput(this), metric, threshold, minSliceLength, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize)
 	}


### PR DESCRIPTION
It makes code easier to read!
I thought it was faster to do it than to make a feature request. Feel free to trash it if it doesn't fit your choices or you think the naming is not right... but I think it's a nice addition, like you have consts for activation functions in FluidMLP.

Note: for Onsets I chose to stick to SC Onsets naming as much as possible.

~~I've added an enum also for FluidSpectralShape and FluidBufStats, which I thought are nice when selecting channels.
FluidBufStats is the only case where I added the enum to the "Buf" class, and I did so because the RT one returns only mean and stdDev.~~ (removed in favor of #78)