### PR TITLE
Fix/scaler invert

### DIFF
--- a/include/wrapper/Messaging.hpp
+++ b/include/wrapper/Messaging.hpp
@@ -35,6 +35,22 @@ struct FluidSCMessaging{
   };
   
 
+private:
+  static bool is_vowel(const char p_char)
+  {
+      constexpr char vowels[] = { 'a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U' };
+      return std::find(std::begin(vowels), std::end(vowels), p_char) != std::end(vowels);
+  }
+
+  static std::string remove_vowel(std::string st)
+  {
+      auto to_erase = std::remove_if(st.begin(), st.end(), is_vowel);
+      st.erase(to_erase, st.end());
+      return st;
+  }
+
+
+public:
   template <size_t N, typename T>
   struct SetupMessageCmd
   {
@@ -42,8 +58,13 @@ struct FluidSCMessaging{
     void operator()(const T& message)
     {
       static std::string messageName = std::string{getName()} + '/' + message.name;
-      auto ft = getInterfaceTable();      
-      ft->fDefinePlugInCmd(messageName.c_str(), doMessage<N>,(void*)messageName.c_str());
+      
+      if(messageName.size() >= 32u)
+        messageName = remove_vowel(messageName);
+            
+      auto ft = getInterfaceTable();
+      if(!ft->fDefinePlugInCmd(messageName.c_str(), doMessage<N>,(void*)messageName.c_str()))
+        std::cout << "ERROR: failed to register command \"" << messageName << "\"\n";
     }
   };
   

--- a/release-packaging/Classes/FluidNormalize.sc
+++ b/release-packaging/Classes/FluidNormalize.sc
@@ -2,13 +2,13 @@ FluidNormalize : FluidModelObject {
 
     var <>min, <>max, <>invert;
 
-	*new {|server, min = 0, max = 1, invert = 0|
-		^super.new(server,[min,max,invert])
-        .min_(min).max_(max).invert_(invert);
+	*new {|server, min = 0, max = 1|
+		^super.new(server,[min,max])
+        .min_(min).max_(max);
 	}
 
     prGetParams{
-        ^[this.id, this.min,this.max,this.invert,-1,-1];
+        ^[this.id, this.min,this.max,-1,-1];
     }
 
 
@@ -52,16 +52,37 @@ FluidNormalize : FluidModelObject {
         this.prSendMsg(this.transformPointMsg(sourceBuffer, destBuffer));
 	}
 
+    inverseTransformMsg{|sourceDataSet, destDataSet|
+        ^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
+    }
+
+	inverseTransform{|sourceDataSet, destDataSet, action|
+		actions[\inverseTransform] = [nil,action];
+        this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
+	}
+
+    inverseTransformPointMsg{|sourceBuffer, destBuffer|
+        ^this.prMakeMsg(\inverseTransformPoint,id,
+            this.prEncodeBuffer(sourceBuffer),
+            this.prEncodeBuffer(destBuffer),
+            ["/b_query",destBuffer.asUGenInput]
+        );
+    }
+
+	inverseTransformPoint{|sourceBuffer, destBuffer, action|
+        actions[\inverseTransformPoint] = [nil,{action.value(destBuffer)}];
+        this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
+	}
+
     kr{|trig, inputBuffer,outputBuffer,min = 0 ,max = 1,invert = 0|
 
         min = min ? this.min;
         max = max ? this.max;
-        invert = invert ? this.invert;
 
-        this.min_(min).max_(max).invert_(invert);
+        this.min_(min).max_(max);
 
         ^FluidNormalizeQuery.kr(trig,
-                this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.min, this.max, this.invert);
+                this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.min, this.max, invert);
     }
 
 

--- a/release-packaging/Classes/FluidRobustScale.sc
+++ b/release-packaging/Classes/FluidRobustScale.sc
@@ -1,14 +1,14 @@
 FluidRobustScale : FluidModelObject {
 
-    var <>low, <>high, <>invert;
+    var <>low, <>high;
 
 	*new {|server, low = 25, high = 75, invert = 0|
 		^super.new(server,[low,high,invert])
-		.low_(low).high_(high).invert_(invert);
+		.low_(low).high_(high);
 	}
 
     prGetParams{
-        ^[this.id,this.low,this.high,this.invert];
+        ^[this.id,this.low,this.high];
     }
 
 
@@ -52,13 +52,31 @@ FluidRobustScale : FluidModelObject {
         this.prSendMsg(this.transformPointMsg(sourceBuffer, destBuffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer,invert|
+    inverseTransformMsg{|sourceDataSet, destDataSet|
+        ^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
+    }
 
-		invert = invert ? this.invert;
+	inverseTransform{|sourceDataSet, destDataSet, action|
+		actions[\inverseTransform] = [nil,action];
+        this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
+	}
 
-        // this.invert_(invert);
+    inverseTransformPointMsg{|sourceBuffer, destBuffer|
+        ^this.prMakeMsg(\inverseTransformPoint,id,
+            this.prEncodeBuffer(sourceBuffer),
+            this.prEncodeBuffer(destBuffer),
+            ["/b_query",destBuffer.asUGenInput]
+        );
+    }
 
-        ^FluidRobustScaleQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), invert,);
+	inverseTransformPoint{|sourceBuffer, destBuffer, action|
+        actions[\inverseRransformPoint] = [nil,{action.value(destBuffer)}];
+        this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
+	}
+
+    kr{|trig, inputBuffer,outputBuffer,invert = 0|
+
+        ^FluidRobustScaleQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), invert);
     }
 
 

--- a/release-packaging/Classes/FluidServerObject.sc
+++ b/release-packaging/Classes/FluidServerObject.sc
@@ -56,7 +56,12 @@ FluidServerObject
     }
 
     prMakeMsg{|msg,id...args|
-        ^['/cmd',"%/%".format(this.class.objectClassName,msg),id].addAll(args);
+
+        var commandName = "%/%".format(this.class.objectClassName,msg);
+
+        if(commandName.size >= 32) { commandName = commandName.select{|c|c.isVowel.not}};
+
+        ^['/cmd',commandName,id].addAll(args);
     }
 
     freeMsg {

--- a/release-packaging/Classes/FluidStandardize.sc
+++ b/release-packaging/Classes/FluidStandardize.sc
@@ -3,11 +3,11 @@ FluidStandardize : FluidModelObject {
     var <>invert;
 
     *new {|server, invert = 0|
-		^super.new(server,[invert]).invert_(invert);
+		^super.new(server,[]);
 	}
 
     prGetParams{
-        ^[this.id, this.invert];
+        ^[this.id];
     }
 
 	fitMsg{|dataSet|
@@ -47,12 +47,31 @@ FluidStandardize : FluidModelObject {
         this.prSendMsg(this.transformPointMsg(sourceBuffer,destBuffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer,invert|
+    inverseTransformMsg{|sourceDataSet, destDataSet|
+        ^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
+    }
 
-        invert = invert ? this.invert;
-        this.invert_(invert);
+	inverseTransform{|sourceDataSet, destDataSet, action|
+		actions[\inverseTransform] = [nil,action];
+        this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
+	}
 
-        ^FluidStandardizeQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.invert);
+    inverseTransformPointMsg{|sourceBuffer, destBuffer|
+        ^this.prMakeMsg(\inverseTransformPoint,id,
+            this.prEncodeBuffer(sourceBuffer),
+            this.prEncodeBuffer(destBuffer),
+            ["/b_query",destBuffer.asUGenInput]
+        );
+    }
+
+	inverseTransformPoint{|sourceBuffer, destBuffer, action|
+        actions[\inverseRransformPoint] = [nil,{action.value(destBuffer)}];
+        this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
+	}
+
+    kr{|trig, inputBuffer,outputBuffer,invert = 0|
+
+        ^FluidStandardizeQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), invert);
     }
 }
 


### PR DESCRIPTION
* Replaces `invert` parameters in scalers with `inverseTransform<Point>` messages
* Works around character limit in SC plugin command names (can't reliably truncate, so remove all vowels instead 💩 )