### PR TITLE
slicers: change algo/metric select to symbols

### DIFF
--- a/release-packaging/Classes/FluidBufNoveltyFeature.sc
+++ b/release-packaging/Classes/FluidBufNoveltyFeature.sc
@@ -6,6 +6,10 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
 		source = source.asUGenInput;
 		features = features.asUGenInput;
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+			("FluidBufNoveltySlice: % is not a recognised algorithm")
+			.format(algorithm).throw;
+		};
 
 		source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
 		features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
@@ -20,6 +24,10 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
         source = source.asUGenInput;
         features = features.asUGenInput;
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+			("FluidBufNoveltySlice: % is not a recognised algorithm")
+			.format(algorithm).throw;
+		};
 
         source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
         features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
@@ -40,6 +48,10 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
         source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
         features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+			("FluidBufNoveltySlice: % is not a recognised algorithm")
+			.format(algorithm).throw;
+		};
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufNoveltyFeature.sc
+++ b/release-packaging/Classes/FluidBufNoveltyFeature.sc
@@ -24,7 +24,8 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
         source = source.asUGenInput;
         features = features.asUGenInput;
-		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
+		if (algorithm.isNil or: algorithm.isUGen) {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")
 			.format(algorithm).throw;
 		};
@@ -48,7 +49,8 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
         source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
         features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
-		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
+		if (algorithm.isNil or: algorithm.isUGen) {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")
 			.format(algorithm).throw;
 		};

--- a/release-packaging/Classes/FluidBufNoveltySlice.sc
+++ b/release-packaging/Classes/FluidBufNoveltySlice.sc
@@ -24,7 +24,8 @@ FluidBufNoveltySlice : FluidBufProcessor {
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
-        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
+	if (algorithm.isNil or: algorithm.isUGen) {
             ("FluidBufNoveltySlice: % is not a recognised algorithm")
             .format(algorithm).throw;
         };
@@ -45,7 +46,8 @@ FluidBufNoveltySlice : FluidBufProcessor {
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
-        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
+	if (algorithm.isNil or: algorithm.isUGen) {
             ("FluidBufNoveltySlice: % is not a recognised algorithm")
             .format(algorithm).throw;
         };

--- a/release-packaging/Classes/FluidBufNoveltySlice.sc
+++ b/release-packaging/Classes/FluidBufNoveltySlice.sc
@@ -1,11 +1,15 @@
 FluidBufNoveltySlice : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm = 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1 , blocking = 0| 
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm = 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1 , blocking = 0|
 
         var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
 		source = source.asUGenInput;
 		indices = indices.asUGenInput;
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+			("FluidBufNoveltySlice: % is not a recognised algorithm")
+			.format(algorithm).throw;
+		};
 
 		source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
 		indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
@@ -15,15 +19,19 @@ FluidBufNoveltySlice : FluidBufProcessor {
 	}
 
     *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm= 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action |
-        
+
         var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
+        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+            ("FluidBufNoveltySlice: % is not a recognised algorithm")
+            .format(algorithm).throw;
+        };
 
         source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
         indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
-        
+
 		^this.new(
 			server, nil, [indices]
 		).processList(
@@ -32,15 +40,19 @@ FluidBufNoveltySlice : FluidBufProcessor {
 	}
 
     *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm= 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action |
-        
+
         var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
+        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
+            ("FluidBufNoveltySlice: % is not a recognised algorithm")
+            .format(algorithm).throw;
+        };
 
         source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
         indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
-        
+
 		^this.new(
 			server, nil, [indices]
 		).processList(

--- a/release-packaging/Classes/FluidBufOnsetFeature.sc
+++ b/release-packaging/Classes/FluidBufOnsetFeature.sc
@@ -22,7 +22,8 @@ FluidBufOnsetFeature : FluidBufProcessor {
 
         source = source.asUGenInput;
         features = features.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+        metric = FluidOnsetSlice.prSelectMetric(metric);
+	if (metric.isNil or: metric.isUGen) {
             ("FluidBufOnsetSlice: % is not a recognised metric")
             .format(metric).throw;
         };
@@ -43,7 +44,8 @@ FluidBufOnsetFeature : FluidBufProcessor {
 
         source = source.asUGenInput;
         features = features.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+        metric = FluidOnsetSlice.prSelectMetric(metric);
+	if (metric.isNil or: metric.isUGen) {
             ("FluidBufOnsetSlice: % is not a recognised metric")
             .format(metric).throw;
         };

--- a/release-packaging/Classes/FluidBufOnsetFeature.sc
+++ b/release-packaging/Classes/FluidBufOnsetFeature.sc
@@ -5,6 +5,10 @@ FluidBufOnsetFeature : FluidBufProcessor {
 
         source = source.asUGenInput;
         features = features.asUGenInput;
+        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+            ("FluidBufOnsetSlice: % is not a recognised metric")
+            .format(metric).throw;
+        };
 
         source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
         features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
@@ -18,6 +22,10 @@ FluidBufOnsetFeature : FluidBufProcessor {
 
         source = source.asUGenInput;
         features = features.asUGenInput;
+        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+            ("FluidBufOnsetSlice: % is not a recognised metric")
+            .format(metric).throw;
+        };
 
         source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
         features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
@@ -35,6 +43,10 @@ FluidBufOnsetFeature : FluidBufProcessor {
 
         source = source.asUGenInput;
         features = features.asUGenInput;
+        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+            ("FluidBufOnsetSlice: % is not a recognised metric")
+            .format(metric).throw;
+        };
 
         source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
         features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};

--- a/release-packaging/Classes/FluidBufOnsetSlice.sc
+++ b/release-packaging/Classes/FluidBufOnsetSlice.sc
@@ -23,7 +23,8 @@ FluidBufOnsetSlice : FluidBufProcessor {
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+        metric = FluidOnsetSlice.prSelectMetric(metric);
+	if (metric.isNil or: metric.isUGen) {
             ("FluidBufOnsetSlice: % is not a recognised metric")
             .format(metric).throw;
         };
@@ -44,7 +45,8 @@ FluidBufOnsetSlice : FluidBufProcessor {
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+        metric = FluidOnsetSlice.prSelectMetric(metric);
+	if (metric.isNil or: metric.isUGen) {
             ("FluidBufOnsetSlice: % is not a recognised metric")
             .format(metric).throw;
         };

--- a/release-packaging/Classes/FluidBufOnsetSlice.sc
+++ b/release-packaging/Classes/FluidBufOnsetSlice.sc
@@ -1,27 +1,36 @@
 FluidBufOnsetSlice : FluidBufProcessor {
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0| 
-        
+
+    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
+
         var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
+        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+            ("FluidBufOnsetSlice: % is not a recognised metric")
+            .format(metric).throw;
+        };
 
         source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
         indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
-                
+
 		^FluidProxyUgen.kr(\FluidBufOnsetSliceTrigger, -1, source, startFrame, numFrames, startChan, numChans, indices, metric, threshold, minSliceLength, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
 
     *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
-        
+
         var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
+        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+            ("FluidBufOnsetSlice: % is not a recognised metric")
+            .format(metric).throw;
+        };
 
         source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
         indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
-                
+
 		^this.new(
 			server, nil, [indices]
 		).processList(
@@ -30,15 +39,19 @@ FluidBufOnsetSlice : FluidBufProcessor {
 	}
 
     *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
-        
+
         var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
         source = source.asUGenInput;
         indices = indices.asUGenInput;
+        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+            ("FluidBufOnsetSlice: % is not a recognised metric")
+            .format(metric).throw;
+        };
 
         source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
         indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
-                
+
 		^this.new(
 			server, nil, [indices]
 		).processList(

--- a/release-packaging/Classes/FluidNoveltyFeature.sc
+++ b/release-packaging/Classes/FluidNoveltyFeature.sc
@@ -1,13 +1,19 @@
 FluidNoveltyFeature : FluidRTUGen {
 	*kr { arg in = 0, algorithm = 0, kernelSize = 3, filterSize = 1, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1, maxKernelSize, maxFilterSize;
-        
-        maxKernelSize = maxKernelSize ? kernelSize; 
-        maxFilterSize = maxFilterSize ? filterSize; 
-        
+
+        maxKernelSize = maxKernelSize ? kernelSize;
+        maxFilterSize = maxFilterSize ? filterSize;
+        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm)  ?? {
+            ("FluidNoveltySlice: % is not a recognised algorithm").format(algorithm);
+        };
+
 		^this.multiNew('control', in.asAudioRateInput(this), algorithm, kernelSize, maxKernelSize, filterSize, maxFilterSize, windowSize, hopSize, fftSize, maxFFTSize)
 	}
-    
+
 	checkInputs {
+		if(inputs.at(1).rate != 'scalar') {
+			^(": invalid algorithm");
+		    };
 		if(inputs.at(9).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
 			};

--- a/release-packaging/Classes/FluidNoveltyFeature.sc
+++ b/release-packaging/Classes/FluidNoveltyFeature.sc
@@ -11,7 +11,7 @@ FluidNoveltyFeature : FluidRTUGen {
 	}
 
 	checkInputs {
-		if(inputs.at(1).rate != 'scalar') {
+		if([\scalar, \control].includes(inputs.at(1).rate).not) {
 			^(": invalid algorithm");
 		    };
 		if(inputs.at(9).rate != 'scalar') {

--- a/release-packaging/Classes/FluidNoveltySlice.sc
+++ b/release-packaging/Classes/FluidNoveltySlice.sc
@@ -1,20 +1,34 @@
 FluidNoveltySlice : FluidRTUGen {
 
-	const <spectrum = 0;
-	const <mfcc = 1;
-	const <chroma = 2;
-	const <pitch = 3;
-	const <loudness = 4;
+	const <algorithms = #[\spectrum, \mfcc, \chroma, \pitch, \loudness];
+
+	*prSelectAlgorithm { |sym|
+		if (sym.isNumber) {
+			if (sym >= 0 && (sym < algorithms.size)) {
+				^sym
+			} {
+				^nil
+			}
+		};
+		^algorithms.indexOf(sym.asSymbol)
+	}
 
 	*ar { arg in = 0, algorithm = 0, kernelSize = 3, threshold = 0.8, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1, maxKernelSize, maxFilterSize;
-        
+
         maxKernelSize = maxKernelSize ? kernelSize;
-        maxFilterSize = maxFilterSize ? filterSize; 
-        
+        maxFilterSize = maxFilterSize ? filterSize;
+
+        algorithm = this.prSelectAlgorithm(algorithm)  ?? {
+            ("FluidNoveltySlice: % is not a recognised algorithm").format(algorithm);
+        };
+
 		^this.multiNew('audio', in.asAudioRateInput(this), algorithm, kernelSize, maxKernelSize, threshold, filterSize,  maxFilterSize, minSliceLength, windowSize, hopSize, fftSize, maxFFTSize)
 	}
 
 	checkInputs {
+		if(inputs.at(1).rate != 'scalar') {
+			^(": invalid algorithm");
+		    };
 		if(inputs.at(11).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
 			};

--- a/release-packaging/Classes/FluidNoveltySlice.sc
+++ b/release-packaging/Classes/FluidNoveltySlice.sc
@@ -3,6 +3,7 @@ FluidNoveltySlice : FluidRTUGen {
 	const <algorithms = #[\spectrum, \mfcc, \chroma, \pitch, \loudness];
 
 	*prSelectAlgorithm { |sym|
+		if (sym.isUGen) { ^sym };
 		if (sym.isNumber) {
 			if (sym >= 0 && (sym < algorithms.size)) {
 				^sym
@@ -26,7 +27,7 @@ FluidNoveltySlice : FluidRTUGen {
 	}
 
 	checkInputs {
-		if(inputs.at(1).rate != 'scalar') {
+		if([\scalar, \control].includes(inputs.at(1).rate).not) {
 			^(": invalid algorithm");
 		    };
 		if(inputs.at(11).rate != 'scalar') {

--- a/release-packaging/Classes/FluidOnsetFeature.sc
+++ b/release-packaging/Classes/FluidOnsetFeature.sc
@@ -8,7 +8,7 @@ FluidOnsetFeature : FluidRTUGen {
 		^this.multiNew('control', in.asAudioRateInput(this), metric, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize)
 	}
 	checkInputs {
-		if(inputs.at(1).rate != 'scalar') {
+		if([\scalar, \control].includes(inputs.at(1).rate).not) {
 			^(": invalid metric");
 		    };
 		if(inputs.at(7).rate != 'scalar') {

--- a/release-packaging/Classes/FluidOnsetFeature.sc
+++ b/release-packaging/Classes/FluidOnsetFeature.sc
@@ -1,8 +1,16 @@
 FluidOnsetFeature : FluidRTUGen {
 	*kr { arg in = 0, metric = 0, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
+
+		metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+			("% is not a recognised metric").format(metric);
+		};
+
 		^this.multiNew('control', in.asAudioRateInput(this), metric, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize)
 	}
 	checkInputs {
+		if(inputs.at(1).rate != 'scalar') {
+			^(": invalid metric");
+		    };
 		if(inputs.at(7).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
 			};

--- a/release-packaging/Classes/FluidOnsetSlice.sc
+++ b/release-packaging/Classes/FluidOnsetSlice.sc
@@ -14,6 +14,7 @@ FluidOnsetSlice : FluidRTUGen {
 	];
 
 	*prSelectMetric { |sym|
+		if (sym.isUGen) { ^sym };
 		if (sym.isNumber) {
 			if (sym >= 0 && (sym < metrics.size)) {
 				^sym
@@ -33,7 +34,7 @@ FluidOnsetSlice : FluidRTUGen {
 		^this.multiNew('audio', in.asAudioRateInput(this), metric, threshold, minSliceLength, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize)
 	}
 	checkInputs {
-		if(inputs.at(1).rate != 'scalar') {
+		if([\scalar, \control].includes(inputs.at(1).rate).not) {
 			^(": invalid metric");
 		    };
 		if(inputs.at(9).rate != 'scalar') {

--- a/release-packaging/Classes/FluidOnsetSlice.sc
+++ b/release-packaging/Classes/FluidOnsetSlice.sc
@@ -1,20 +1,41 @@
 FluidOnsetSlice : FluidRTUGen {
 
-	const <power = 0;
-	const <hfc = 1;
-	const <flux = 2;
-	const <mkl = 3;
-	const <is = 4;
-	const <cosine = 5;
-	const <phase = 6;
-	const <wphase = 7;
-	const <complex = 8;
-	const <rcomplex = 9;
+	const <metrics = #[
+		\power,
+		\hfc,
+		\flux,
+		\mkl,
+		\is,
+		\cosine,
+		\phase,
+		\wphase,
+		\complex,
+		\rcomplex,
+	];
+
+	*prSelectMetric { |sym|
+		if (sym.isNumber) {
+			if (sym >= 0 && (sym < metrics.size)) {
+				^sym
+			} {
+				^nil
+			}
+		};
+		^metrics.indexOf(sym.asSymbol)
+	}
 
 	*ar { arg in = 0, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
+
+		metric = this.prSelectMetric(metric) ?? {
+			("% is not a recognised metric").format(metric);
+		};
+
 		^this.multiNew('audio', in.asAudioRateInput(this), metric, threshold, minSliceLength, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize)
 	}
 	checkInputs {
+		if(inputs.at(1).rate != 'scalar') {
+			^(": invalid metric");
+		    };
 		if(inputs.at(9).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
 			};


### PR DESCRIPTION
Following up #86, after seeing how the new "select" mechanism work, I think it would be better to select algorithms (in FluidNoveltySlice) and metrics (in FluidOnsetSlice) by passing symbols, rather than using "structs". Just not too have too many different interfaces, that could end up being confusing.
I think it's also best to raise this now, since #86 didn't reach a beta yet.

Just to be clear, the difference is:
```supercollider
// using structs
FluidNoveltySlice.ar(in, algorithm: FluidNoveltySlice.mfcc)
// using symbols
FluidNoveltySlice.ar(in, algorithm: \mfcc)
``` 
And I think the latter fits better with `FluidBufStats.process(select: [\low])`

If you decide to adopt this, maybe it's worth changing FluidMLP activation selection as well?

Implementation question: I used lists, maybe you prefer dictionaries? it would be an easy change.