### PR TITLE
[Enhance] Interp to Interpolation in NMFMorph

### DIFF
--- a/release-packaging/Classes/FluidNMFMorph.sc
+++ b/release-packaging/Classes/FluidNMFMorph.sc
@@ -1,12 +1,12 @@
 FluidNMFMorph : FluidRTUGen {
 
-	*ar { arg source = -1, target = -1, activations = -1, autoassign = 1, interp = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
+	*ar { arg source = -1, target = -1, activations = -1, autoassign = 1, interpolation = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
 
 		source = source ?? {-1};
 		target = target ?? {-1};
 		activations = activations ?? {-1};
 
-		^this.new1('audio', source, target, activations, autoassign, interp, windowSize, hopSize, fftSize, maxFFTSize);
+		^this.new1('audio', source, target, activations, autoassign, interpolation, windowSize, hopSize, fftSize, maxFFTSize);
 	}
 
 	init {arg ...theInputs;


### PR DESCRIPTION
Changes the parameter `interp` to `interpolation` for the NMFMorph client.

This normalises it to be the same as other objects which have a similarly named parameter.

Relevant PRs:
https://github.com/flucoma/flucoma-sc/pull/115
https://github.com/flucoma/flucoma-core/pull/174
https://github.com/flucoma/flucoma-docs/pull/143
