### PR TITLE
Docs: add read and write methods to FluidDataSet

### DIFF
--- a/release-packaging/HelpSource/Classes/FluidDataSet.schelp
+++ b/release-packaging/HelpSource/Classes/FluidDataSet.schelp
@@ -23,6 +23,21 @@ INSTANCEMETHODS::
 ​
 PRIVATE:: init,id,cache
 
+
+METHOD:: write
+Write data set as json file.
+ARGUMENT:: filename
+The file to save into.
+ARGUMENT:: action
+A function to run when the operation completes.
+
+METHOD:: read
+Read data set as json file.
+ARGUMENT:: filename
+The file to read from.
+ARGUMENT:: action
+A function to run when the operation completes.
+
 METHOD:: addPoint
 Add a new point to the FluidDataSet. The dimensionality of the FluidDataSet is governed by the size of the first point added. If the identifier already exists, or if the size of the data does not match the dimensionality of the FluidDataSet an error will be reported.
 Will report an error if the identifier already exists, or if the size of the data does not match the dimensionality of the DataSet.


### PR DESCRIPTION
It is not obvious that you can do this without looking through the documentation for FluidDataObject. Perhaps this could go in FluidDataObject, but since that isn't implemented yet, this seems simplest.

https://discourse.flucoma.org/t/weird-behaviour-when-loading-a-large-ish-dataset-from-file-supercollider/1600/3
