### PR TITLE
Classes: uniform sc default indentation

### DIFF
--- a/release-packaging/Classes/FluidAmpGate.sc
+++ b/release-packaging/Classes/FluidAmpGate.sc
@@ -5,7 +5,7 @@ FluidAmpGate : FluidRTUGen {
 	checkInputs {
 		if(inputs.at(12).rate != 'scalar') {
 			^(": maxSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidAudioTransport.sc
+++ b/release-packaging/Classes/FluidAudioTransport.sc
@@ -1,11 +1,11 @@
 FluidAudioTransport : FluidRTUGen {
 
-    init { |...theInputs|
-        theInputs;
-        inputs = theInputs;
-        this.specialIndex = 1; //two audio inputs
-        // ^this.initOutputs(1,rate);
-    }
+	init { |...theInputs|
+		theInputs;
+		inputs = theInputs;
+		this.specialIndex = 1; //two audio inputs
+		// ^this.initOutputs(1,rate);
+	}
 
 	*ar { arg in = 0, in2 = 0, interpolation = 0.0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
 		^this.multiNew('audio', in.asAudioRateInput, in2, interpolation, windowSize, hopSize, fftSize, maxFFTSize)

--- a/release-packaging/Classes/FluidBufAmpFeature.sc
+++ b/release-packaging/Classes/FluidBufAmpFeature.sc
@@ -1,38 +1,38 @@
 FluidBufAmpFeature : FluidBufProcessor {
 
-	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, trig = 1, blocking = 0| 
-        
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, trig = 1, blocking = 0|
 
-        source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
-                
+		source = source.asUGenInput;
+		features = features.asUGenInput;
+
+		source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
+
 		^FluidProxyUgen.kr(\FluidBufAmpFeatureTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, fastRampUp, fastRampDown, slowRampUp, slowRampDown, floor, highPassFreq, trig, blocking);
 	}
 
-    *process { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, freeWhenDone = true, action |
+	*process { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, freeWhenDone = true, action |
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
 
-		^this.new(server, nil, [features]).processList(            
+		^this.new(server, nil, [features]).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, fastRampUp, fastRampDown, slowRampUp, slowRampDown, floor, highPassFreq,0],freeWhenDone, action
 		);
 	}
 
-    *processBlocking { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, freeWhenDone = true, action |
+	*processBlocking { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, freeWhenDone = true, action |
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
 
-		^this.new(server, nil, [features]).processList(            
+		^this.new(server, nil, [features]).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, fastRampUp, fastRampDown, slowRampUp, slowRampDown, floor, highPassFreq,1],freeWhenDone, action
 		);
 	}

--- a/release-packaging/Classes/FluidBufAmpGate.sc
+++ b/release-packaging/Classes/FluidBufAmpGate.sc
@@ -1,44 +1,44 @@
 FluidBufAmpGate : FluidBufProcessor {
 
-	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, rampUp = 10, rampDown = 10, onThreshold = -90, offThreshold = -90, minSliceLength = 1, minSilenceLength = 1, minLengthAbove = 1, minLengthBelow = 1, lookBack = 0, lookAhead = 0, highPassFreq = 85, trig = 1, blocking = 0| 
-        
-        var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, rampUp = 10, rampDown = 10, onThreshold = -90, offThreshold = -90, minSliceLength = 1, minSilenceLength = 1, minLengthAbove = 1, minLengthBelow = 1, lookBack = 0, lookAhead = 0, highPassFreq = 85, trig = 1, blocking = 0|
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
-                
+		var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
+
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
+
 		^FluidProxyUgen.kr(\FluidBufAmpGateTrigger,-1, source, startFrame, numFrames, startChan, numChans, indices, rampUp, rampDown, onThreshold, offThreshold, minSliceLength, minSilenceLength, minLengthAbove, minLengthBelow, lookBack, lookAhead, highPassFreq,maxSize,  trig, blocking);
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, rampUp = 10, rampDown = 10, onThreshold = -90, offThreshold = -90, minSliceLength = 1, minSilenceLength = 1, minLengthAbove = 1, minLengthBelow = 1, lookBack = 0, lookAhead = 0, highPassFreq = 85, freeWhenDone = true, action |
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, rampUp = 10, rampDown = 10, onThreshold = -90, offThreshold = -90, minSliceLength = 1, minSilenceLength = 1, minLengthAbove = 1, minLengthBelow = 1, lookBack = 0, lookAhead = 0, highPassFreq = 85, freeWhenDone = true, action |
 
 
-        var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
+		var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
 
 		source = source ? -1;
-		indices = indices ? -1; 
+		indices = indices ? -1;
 
 		^this.new(
 			server, nil, [indices]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, indices, rampUp, rampDown, onThreshold, offThreshold, minSliceLength, minSilenceLength, minLengthAbove, minLengthBelow, lookBack, lookAhead, highPassFreq, maxSize, 0],freeWhenDone,action
-        );
+		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, rampUp = 10, rampDown = 10, onThreshold = -90, offThreshold = -90, minSliceLength = 1, minSilenceLength = 1, minLengthAbove = 1, minLengthBelow = 1, lookBack = 0, lookAhead = 0, highPassFreq = 85, freeWhenDone = true, action |
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, rampUp = 10, rampDown = 10, onThreshold = -90, offThreshold = -90, minSliceLength = 1, minSilenceLength = 1, minLengthAbove = 1, minLengthBelow = 1, lookBack = 0, lookAhead = 0, highPassFreq = 85, freeWhenDone = true, action |
 
 
-        var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
+		var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
 
-       source = source ? -1;
-       indices = indices ? -1; 
+		source = source ? -1;
+		indices = indices ? -1;
 
-       ^this.new(
-           server, nil, [indices]
-       ).processList(
-           [source, startFrame, numFrames, startChan, numChans, indices, rampUp, rampDown, onThreshold, offThreshold, minSliceLength, minSilenceLength, minLengthAbove, minLengthBelow, lookBack, lookAhead, highPassFreq, maxSize, 1],freeWhenDone,action
-        );
-   }
-   
+		^this.new(
+			server, nil, [indices]
+		).processList(
+			[source, startFrame, numFrames, startChan, numChans, indices, rampUp, rampDown, onThreshold, offThreshold, minSliceLength, minSilenceLength, minLengthAbove, minLengthBelow, lookBack, lookAhead, highPassFreq, maxSize, 1],freeWhenDone,action
+		);
+	}
+
 }
 FluidBufAmpGateTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufAmpSlice.sc
+++ b/release-packaging/Classes/FluidBufAmpSlice.sc
@@ -1,38 +1,38 @@
 FluidBufAmpSlice : FluidBufProcessor {
 
-	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, trig = 1, blocking = 0| 
-        
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, trig = 1, blocking = 0|
 
-        source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
-        indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
-                
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
+
+		source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
+		indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
+
 		^FluidProxyUgen.kr(\FluidBufAmpSliceTrigger, -1, source, startFrame, numFrames, startChan, numChans, indices, fastRampUp, fastRampDown, slowRampUp, slowRampDown, onThreshold, offThreshold, floor, minSliceLength, highPassFreq, trig, blocking);
 	}
 
-    *process { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, freeWhenDone = true, action |
+	*process { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, freeWhenDone = true, action |
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
 
-        source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
-        indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
+		indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
 
-		^this.new(server, nil, [indices]).processList(            
+		^this.new(server, nil, [indices]).processList(
 			[source, startFrame, numFrames, startChan, numChans, indices, fastRampUp, fastRampDown, slowRampUp, slowRampDown, onThreshold, offThreshold, floor, minSliceLength, highPassFreq,0],freeWhenDone, action
 		);
 	}
 
-    *processBlocking { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, freeWhenDone = true, action |
+	*processBlocking { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, freeWhenDone = true, action |
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
 
-        source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
-        indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
+		indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
 
-		^this.new(server, nil, [indices]).processList(            
+		^this.new(server, nil, [indices]).processList(
 			[source, startFrame, numFrames, startChan, numChans, indices, fastRampUp, fastRampDown, slowRampUp, slowRampDown, onThreshold, offThreshold, floor, minSliceLength, highPassFreq,1],freeWhenDone, action
 		);
 	}

--- a/release-packaging/Classes/FluidBufAudioTransport.sc
+++ b/release-packaging/Classes/FluidBufAudioTransport.sc
@@ -2,14 +2,14 @@ FluidBufAudioTransport : FluidBufProcessor {
 
 	*kr  { |sourceA, startFrameA = 0, numFramesA = -1, startChanA = 0, numChansA = -1, sourceB, startFrameB = 0, numFramesB = -1, startChanB = 0, numChansB = -1, destination, interpolation = 0.0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
-        sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
-        sourceA = sourceA.asUGenInput;
-        sourceB = sourceB.asUGenInput;
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
+		sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
+		sourceA = sourceA.asUGenInput;
+		sourceB = sourceB.asUGenInput;
 
-        destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
-        destination = destination.asUGenInput;
+		destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
+		destination = destination.asUGenInput;
 
 
 		^FluidProxyUgen.kr(this.objectClassName++\Trigger,-1, sourceA, startFrameA, numFramesA, startChanA, numChansA, sourceB, startFrameA, numFramesA, startChanB, numChansB, destination, interpolation, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
@@ -18,14 +18,14 @@ FluidBufAudioTransport : FluidBufProcessor {
 
 	*process { |server, sourceA, startFrameA = 0, numFramesA = -1, startChanA = 0, numChansA = -1, sourceB, startFrameB = 0, numFramesB = -1, startChanB = 0, numChansB = -1, destination, interpolation=0.0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
-        sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
-        sourceA = sourceA.asUGenInput;
-        sourceB = sourceB.asUGenInput;
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
+		sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
+		sourceA = sourceA.asUGenInput;
+		sourceB = sourceB.asUGenInput;
 
-        destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
-        destination = destination.asUGenInput;
+		destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
+		destination = destination.asUGenInput;
 
 		^this.new(
 			server, nil, [destination]
@@ -34,16 +34,16 @@ FluidBufAudioTransport : FluidBufProcessor {
 		)
 	}
 
-    *processBlocking { |server, sourceA, startFrameA = 0, numFramesA = -1, startChanA = 0, numChansA = -1, sourceB, startFrameB = 0, numFramesB = -1, startChanB = 0, numChansB = -1, destination, interpolation=0.0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
+	*processBlocking { |server, sourceA, startFrameA = 0, numFramesA = -1, startChanA = 0, numChansA = -1, sourceB, startFrameB = 0, numFramesB = -1, startChanB = 0, numChansB = -1, destination, interpolation=0.0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
-        sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
-        sourceA = sourceA.asUGenInput;
-        sourceB = sourceB.asUGenInput;
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
+		sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
+		sourceA = sourceA.asUGenInput;
+		sourceB = sourceB.asUGenInput;
 
-        destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
-        destination = destination.asUGenInput;
+		destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
+		destination = destination.asUGenInput;
 
 		^this.new(
 			server, nil, [destination]

--- a/release-packaging/Classes/FluidBufChroma.sc
+++ b/release-packaging/Classes/FluidBufChroma.sc
@@ -1,49 +1,49 @@
 FluidBufChroma : FluidBufProcessor {
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numChroma = 12, ref = 440, normalize = 0,minFreq = 0,maxFreq = -1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numChroma = 12, ref = 440, normalize = 0,minFreq = 0,maxFreq = -1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufChromaTrigger,-1, source, startFrame, numFrames, startChan, numChans, features, padding, numChroma, numChroma, ref, normalize, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numChroma = 12, ref = 440, normalize = 0,minFreq = 0,maxFreq = -1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numChroma = 12, ref = 440, normalize = 0,minFreq = 0,maxFreq = -1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, padding, numChroma, numChroma, ref, normalize, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize, 0],freeWhenDone,action
-        );
+		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numChroma = 12, ref = 440, normalize = 0,minFreq = 0,maxFreq = -1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numChroma = 12, ref = 440, normalize = 0,minFreq = 0,maxFreq = -1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, padding, numChroma, numChroma, ref, normalize, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize, 1],freeWhenDone,action
-        );
+		);
 	}
 }
 FluidBufChromaTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufCompose.sc
+++ b/release-packaging/Classes/FluidBufCompose.sc
@@ -1,39 +1,39 @@
 FluidBufCompose : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, gain = 1, destination, destStartFrame = 0, destStartChan = 0, destGain = 0, trig = 1, blocking = 1| 
-        
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, gain = 1, destination, destStartFrame = 0, destStartChan = 0, destGain = 0, trig = 1, blocking = 1|
 
-        source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        ^FluidProxyUgen.kr(\FluidBufComposeTrigger,-1, source, startFrame, numFrames, startChan, numChans, gain, destination, destStartFrame, destStartChan, destGain, trig, blocking);
+		source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
+
+		^FluidProxyUgen.kr(\FluidBufComposeTrigger,-1, source, startFrame, numFrames, startChan, numChans, gain, destination, destStartFrame, destStartChan, destGain, trig, blocking);
 	}
 
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, gain = 1, destination, destStartFrame = 0, destStartChan = 0, destGain = 0, freeWhenDone = true, action|
-        
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
-        
-	    ^this.new( server, nil, [destination]).processList([source, startFrame, numFrames, startChan, numChans, gain, destination, destStartFrame, destStartChan, destGain, 1], freeWhenDone, action);//NB always blocking
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
+
+		source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
+
+		^this.new( server, nil, [destination]).processList([source, startFrame, numFrames, startChan, numChans, gain, destination, destStartFrame, destStartChan, destGain, 1], freeWhenDone, action);//NB always blocking
 	}
 
-   *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, gain = 1, destination, destStartFrame = 0, destStartChan = 0, destGain = 0, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, gain = 1, destination, destStartFrame = 0, destStartChan = 0, destGain = 0, freeWhenDone = true, action|
 
-       source = source.asUGenInput;
-       destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-       source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
-       destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
-       
-       ^this.new(
-           server, nil, [destination]
-       ).processList([source, startFrame, numFrames, startChan, numChans, gain, destination, destStartFrame, destStartChan, destGain, 1], freeWhenDone, action);
+		source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
+
+		^this.new(
+			server, nil, [destination]
+		).processList([source, startFrame, numFrames, startChan, numChans, gain, destination, destStartFrame, destStartChan, destGain, 1], freeWhenDone, action);
 	}
 }
 FluidBufComposeTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufFlatten.sc
+++ b/release-packaging/Classes/FluidBufFlatten.sc
@@ -1,47 +1,47 @@
 FluidBufFlatten : FluidBufProcessor {
 
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, axis = 1, trig = 1, blocking = 1|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, axis = 1, trig = 1, blocking = 1|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
 
-        ^FluidProxyUgen.kr(\FluidBufFlattenTrigger,-1,  source, startFrame, numFrames, startChan, numChans, destination, axis, trig, blocking);
+		^FluidProxyUgen.kr(\FluidBufFlattenTrigger,-1,  source, startFrame, numFrames, startChan, numChans, destination, axis, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, axis = 1, freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
 
-	^this.new(
-            server, nil, [destination],
+		^this.new(
+			server, nil, [destination],
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, destination, axis,0],freeWhenDone,action
 		);
 
 	}
 
-   *processBlocking  { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, axis = 1, freeWhenDone = true, action|
+	*processBlocking  { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, axis = 1, freeWhenDone = true, action|
 
-       source = source.asUGenInput;
-       destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-       source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
-       destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
 
-   ^this.new(
-           server, nil, [destination],
-       ).processList(
-           [source, startFrame, numFrames, startChan, numChans, destination, axis,1],freeWhenDone,action
-       );
+		^this.new(
+			server, nil, [destination],
+		).processList(
+			[source, startFrame, numFrames, startChan, numChans, destination, axis,1],freeWhenDone,action
+		);
 
-   }
+	}
 }
 FluidBufFlattenTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufHPSS.sc
+++ b/release-packaging/Classes/FluidBufHPSS.sc
@@ -2,25 +2,25 @@ FluidBufHPSS : FluidBufProcessor {
 
 	*kr  {|source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, harmonic = -1, percussive = -1, residual = -1, harmFilterSize = 17, percFilterSize = 31, maskingMode = 0, harmThreshFreq1 = 0.1, harmThreshAmp1 = 0, harmThreshFreq2 = 0.5, harmThreshAmp2 = 0, percThreshFreq1 = 0.1, percThreshAmp1 = 0, percThreshFreq2 = 0.5, percThreshAmp2 = 0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        harmonic = harmonic ? -1;
-        percussive = percussive ? -1;
-        residual = residual ? -1;
-        source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
+		harmonic = harmonic ? -1;
+		percussive = percussive ? -1;
+		residual = residual ? -1;
+		source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
 
-        ^FluidProxyUgen.kr(\FluidBufHPSSTrigger, -1, source, startFrame, numFrames, startChan, numChans, harmonic, percussive, residual, harmFilterSize, harmFilterSize, percFilterSize, percFilterSize, maskingMode, harmThreshFreq1, harmThreshAmp1, harmThreshFreq2, harmThreshAmp2, percThreshFreq1, percThreshAmp1, percThreshFreq2, percThreshAmp2, windowSize, hopSize, fftSize, maxFFTSize,  trig, blocking
-        );
+		^FluidProxyUgen.kr(\FluidBufHPSSTrigger, -1, source, startFrame, numFrames, startChan, numChans, harmonic, percussive, residual, harmFilterSize, harmFilterSize, percFilterSize, percFilterSize, maskingMode, harmThreshFreq1, harmThreshAmp1, harmThreshFreq2, harmThreshAmp2, percThreshFreq1, percThreshAmp1, percThreshFreq2, percThreshAmp2, windowSize, hopSize, fftSize, maxFFTSize,  trig, blocking
+		);
 	}
 
-   *process {|server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, harmonic = -1, percussive = -1, residual = -1, harmFilterSize = 17, percFilterSize = 31, maskingMode = 0, harmThreshFreq1 = 0.1, harmThreshAmp1 = 0, harmThreshFreq2 = 0.5, harmThreshAmp2 = 0, percThreshFreq1 = 0.1, percThreshAmp1 = 0, percThreshFreq2 = 0.5, percThreshAmp2 = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone=true, action|
+	*process {|server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, harmonic = -1, percussive = -1, residual = -1, harmFilterSize = 17, percFilterSize = 31, maskingMode = 0, harmThreshFreq1 = 0.1, harmThreshAmp1 = 0, harmThreshFreq2 = 0.5, harmThreshAmp2 = 0, percThreshFreq1 = 0.1, percThreshAmp1 = 0, percThreshFreq2 = 0.5, percThreshAmp2 = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone=true, action|
 
-       var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-       harmonic = harmonic ? -1;
-       percussive = percussive ? -1;
-       residual = residual ? -1;
-       source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
+		harmonic = harmonic ? -1;
+		percussive = percussive ? -1;
+		residual = residual ? -1;
+		source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
 
 
 		^this.new(
@@ -31,22 +31,22 @@ FluidBufHPSS : FluidBufProcessor {
 
 	}
 
-    *processBlocking {|server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, harmonic = -1, percussive = -1, residual = -1, harmFilterSize = 17, percFilterSize = 31, maskingMode = 0, harmThreshFreq1 = 0.1, harmThreshAmp1 = 0, harmThreshFreq2 = 0.5, harmThreshAmp2 = 0, percThreshFreq1 = 0.1, percThreshAmp1 = 0, percThreshFreq2 = 0.5, percThreshAmp2 = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone=true, action|
+	*processBlocking {|server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, harmonic = -1, percussive = -1, residual = -1, harmFilterSize = 17, percFilterSize = 31, maskingMode = 0, harmThreshFreq1 = 0.1, harmThreshAmp1 = 0, harmThreshFreq2 = 0.5, harmThreshAmp2 = 0, percThreshFreq1 = 0.1, percThreshAmp1 = 0, percThreshFreq2 = 0.5, percThreshAmp2 = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone=true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        harmonic = harmonic ? -1;
-        percussive = percussive ? -1;
-        residual = residual ? -1;
-        source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
+		harmonic = harmonic ? -1;
+		percussive = percussive ? -1;
+		residual = residual ? -1;
+		source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
 
 
- 		^this.new(
- 			server, nil, [harmonic, percussive, residual].select{|x| x!= -1}
- 		).processList(
- 			[source, startFrame, numFrames, startChan, numChans, harmonic, percussive, residual, harmFilterSize, harmFilterSize, percFilterSize, percFilterSize, maskingMode, harmThreshFreq1, harmThreshAmp1, harmThreshFreq2, harmThreshAmp2, percThreshFreq1, percThreshAmp1, percThreshFreq2, percThreshAmp2, windowSize, hopSize, fftSize, maxFFTSize, 1], freeWhenDone,action
- 		);
+		^this.new(
+			server, nil, [harmonic, percussive, residual].select{|x| x!= -1}
+		).processList(
+			[source, startFrame, numFrames, startChan, numChans, harmonic, percussive, residual, harmFilterSize, harmFilterSize, percFilterSize, percFilterSize, maskingMode, harmThreshFreq1, harmThreshAmp1, harmThreshFreq2, harmThreshAmp2, percThreshFreq1, percThreshAmp1, percThreshFreq2, percThreshAmp2, windowSize, hopSize, fftSize, maxFFTSize, 1], freeWhenDone,action
+		);
 
- 	}
+	}
 }
 FluidBufHPSSTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufLoudness.sc
+++ b/release-packaging/Classes/FluidBufLoudness.sc
@@ -1,76 +1,76 @@
 FluidBufLoudness : FluidBufProcessor{
-    
-    const <features=#[\loudness, \peak];
-    classvar featuresLookup;
 
-    *initClass {
-        featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
-    }
+	const <features=#[\loudness, \peak];
+	classvar featuresLookup;
 
-    *prWarnUnrecognised {|sym| ("WARNING: FluidLoudness -" + sym + "is not a recognised option").postln}
+	*initClass {
+		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
+	}
 
-    *prProcessSelect {|a|
-        var bits;
-        a.asBag.countsDo{|item,count,i|
-            if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-        };
-        bits = a.collect{ |sym|
-            (featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-        }.reduce{|x,y| x | y};
-        ^bits
-    }
-    
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, padding = 1, trig = 1, blocking = 0|
+	*prWarnUnrecognised {|sym| ("WARNING: FluidLoudness -" + sym + "is not a recognised option").postln}
 
-        var maxwindowSize = windowSize.nextPowerOfTwo;
-        
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+	*prProcessSelect {|a|
+		var bits;
+		a.asBag.countsDo{|item,count,i|
+			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
+		};
+		bits = a.collect{ |sym|
+			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
+		}.reduce{|x,y| x | y};
+		^bits
+	}
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, padding = 1, trig = 1, blocking = 0|
 
-        source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-        features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		var maxwindowSize = windowSize.nextPowerOfTwo;
 
-        ^FluidProxyUgen.kr(\FluidBufLoudnessTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, kWeighting, truePeak, windowSize, hopSize, maxwindowSize, trig, blocking);
-    }
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select,  kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, padding = 1, freeWhenDone = true, action|
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        var maxwindowSize = windowSize.nextPowerOfTwo;
-        
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
-        
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
+		features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
 
-        source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-        features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		^FluidProxyUgen.kr(\FluidBufLoudnessTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, kWeighting, truePeak, windowSize, hopSize, maxwindowSize, trig, blocking);
+	}
+
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select,  kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, padding = 1, freeWhenDone = true, action|
+
+		var maxwindowSize = windowSize.nextPowerOfTwo;
+
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+
+		source = source.asUGenInput;
+		features = features.asUGenInput;
+
+		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
+		features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
 
 		^this.new(
 			server, nil, [features]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, kWeighting, truePeak, windowSize, hopSize, maxwindowSize,0],freeWhenDone,action
 		);
-    }
+	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select,  kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, padding = 1, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select,  kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, padding = 1, freeWhenDone = true, action|
 
-        var maxwindowSize = windowSize.nextPowerOfTwo;
-        
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var maxwindowSize = windowSize.nextPowerOfTwo;
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
 
-        source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-        features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source = source.asUGenInput;
+		features = features.asUGenInput;
+
+		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
+		features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
 
 		^this.new(
 			server, nil, [features]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, features,padding, selectbits, kWeighting, truePeak, windowSize, hopSize, maxwindowSize,1],freeWhenDone,action
 		);
-    }
+	}
 }
 FluidBufLoudnessTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufMFCC.sc
+++ b/release-packaging/Classes/FluidBufMFCC.sc
@@ -1,46 +1,46 @@
 FluidBufMFCC : FluidBufProcessor{
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
 
-        ^FluidProxyUgen.kr(\FluidBufMFCCTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, numCoeffs, numCoeffs, numBands, numBands, startCoeff, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize,trig, blocking);
-    }
+		^FluidProxyUgen.kr(\FluidBufMFCCTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, numCoeffs, numCoeffs, numBands, numBands, startCoeff, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize,trig, blocking);
+	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone=true, action |
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone=true, action |
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
-
-		^this.new(
-			server, nil,[features]
-		).processList(
-			 [source, startFrame, numFrames, startChan, numChans, features, padding, numCoeffs, numCoeffs, numBands,  numBands, startCoeff, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize,0],freeWhenDone,action
-		);
-    }
-
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone=true, action |
-
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        source = source.asUGenInput;
-        features = features.asUGenInput;
-
-        source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil,[features]
 		).processList(
-			 [source, startFrame, numFrames, startChan, numChans, features, padding, numCoeffs, numCoeffs, numBands, numBands, startCoeff, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize,1],freeWhenDone,action
+			[source, startFrame, numFrames, startChan, numChans, features, padding, numCoeffs, numCoeffs, numBands,  numBands, startCoeff, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize,0],freeWhenDone,action
 		);
-    }
+	}
+
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone=true, action |
+
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		source = source.asUGenInput;
+		features = features.asUGenInput;
+
+		source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
+
+		^this.new(
+			server, nil,[features]
+		).processList(
+			[source, startFrame, numFrames, startChan, numChans, features, padding, numCoeffs, numCoeffs, numBands, numBands, startCoeff, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize,1],freeWhenDone,action
+		);
+	}
 }
 FluidBufMFCCTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufMelBands.sc
+++ b/release-packaging/Classes/FluidBufMelBands.sc
@@ -1,51 +1,51 @@
 FluidBufMelBands : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numBands = 40, minFreq = 20, maxFreq = 20000, normalize = 1, scale = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numBands = 40, minFreq = 20, maxFreq = 20000, normalize = 1, scale = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
 
 
 		^FluidProxyUgen.kr(\FluidBufMelBandsTrigger,-1, source, startFrame, numFrames, startChan, numChans, features, padding, numBands, numBands,  minFreq, maxFreq,  normalize, scale, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numBands = 40, minFreq = 20, maxFreq = 20000, normalize = 1, scale = 0,  windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numBands = 40, minFreq = 20, maxFreq = 20000, normalize = 1, scale = 0,  windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, padding, numBands, numBands,  minFreq, maxFreq,  normalize, scale, windowSize, hopSize, fftSize, maxFFTSize, 0],freeWhenDone,action
-        );
+		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numBands = 40, minFreq = 20, maxFreq = 20000, normalize = 1, scale = 0,  windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  numBands = 40, minFreq = 20, maxFreq = 20000, normalize = 1, scale = 0,  windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, padding, numBands, numBands,  minFreq, maxFreq,  normalize, scale, windowSize, hopSize, fftSize, maxFFTSize, 1],freeWhenDone,action
-        );
+		);
 	}
 }
 FluidBufMelBandsTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufNMF.sc
+++ b/release-packaging/Classes/FluidBufNMF.sc
@@ -1,37 +1,37 @@
 FluidBufNMF : FluidBufProcessor
 {
-    *kr  {|source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth, resynthMode = 0,  bases, basesMode = 0, activations, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
+	*kr  {|source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth, resynthMode = 0,  bases, basesMode = 0, activations, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-        source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
-        resynth = resynth ? -1;
-        bases = bases ? -1;
-        activations = activations ? -1;
+		source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
+		resynth = resynth ? -1;
+		bases = bases ? -1;
+		activations = activations ? -1;
 
-        ^FluidProxyUgen.kr(\FluidBufNMFTrigger,-1,source.asUGenInput, startFrame, numFrames, startChan, numChans, resynth.asUGenInput, resynthMode, bases.asUGenInput, basesMode, activations.asUGenInput, actMode, components, iterations, windowSize, hopSize, fftSize, fftSize, trig, blocking);
-    }
+		^FluidProxyUgen.kr(\FluidBufNMFTrigger,-1,source.asUGenInput, startFrame, numFrames, startChan, numChans, resynth.asUGenInput, resynthMode, bases.asUGenInput, basesMode, activations.asUGenInput, actMode, components, iterations, windowSize, hopSize, fftSize, fftSize, trig, blocking);
+	}
 
-    *process { |server,  source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth = -1, resynthMode = 0,  bases = -1, basesMode = 0, activations = -1, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1,freeWhenDone = true, action|
+	*process { |server,  source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth = -1, resynthMode = 0,  bases = -1, basesMode = 0, activations = -1, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1,freeWhenDone = true, action|
 
-        source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
-        resynth = resynth ? -1;
-        bases = bases ? -1;
-        activations = activations ? -1;
+		source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
+		resynth = resynth ? -1;
+		bases = bases ? -1;
+		activations = activations ? -1;
 
-       ^this.new(
-            server,nil,[resynth, bases, activations].select{|x| x!= -1}
-        ).processList([source, startFrame, numFrames, startChan, numChans, resynth, resynthMode, bases, basesMode, activations, actMode, components,iterations, windowSize, hopSize, fftSize, fftSize, 0],freeWhenDone,action);
-    }
+		^this.new(
+			server,nil,[resynth, bases, activations].select{|x| x!= -1}
+		).processList([source, startFrame, numFrames, startChan, numChans, resynth, resynthMode, bases, basesMode, activations, actMode, components,iterations, windowSize, hopSize, fftSize, fftSize, 0],freeWhenDone,action);
+	}
 
-    *processBlocking { |server,  source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth = -1, resynthMode = 0, bases = -1, basesMode = 0, activations = -1, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1,freeWhenDone = true, action|
+	*processBlocking { |server,  source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth = -1, resynthMode = 0, bases = -1, basesMode = 0, activations = -1, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1,freeWhenDone = true, action|
 
-        source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
-        resynth = resynth ? -1;
-        bases = bases ? -1;
-        activations = activations ? -1;
+		source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
+		resynth = resynth ? -1;
+		bases = bases ? -1;
+		activations = activations ? -1;
 
-       ^this.new(
-            server,nil,[resynth, bases, activations].select{|x| x!= -1}
-        ).processList([source, startFrame, numFrames, startChan, numChans, resynth, resynthMode, bases, basesMode, activations, actMode, components,iterations, windowSize, hopSize, fftSize, fftSize, 1],freeWhenDone,action);
-    }
+		^this.new(
+			server,nil,[resynth, bases, activations].select{|x| x!= -1}
+		).processList([source, startFrame, numFrames, startChan, numChans, resynth, resynthMode, bases, basesMode, activations, actMode, components,iterations, windowSize, hopSize, fftSize, fftSize, 1],freeWhenDone,action);
+	}
 }
 FluidBufNMFTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufNMFCross.sc
+++ b/release-packaging/Classes/FluidBufNMFCross.sc
@@ -1,45 +1,45 @@
 FluidBufNMFCross : FluidBufProcessor {
 
-    *kr  { |source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
+	*kr  { |source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-        source = source.asUGenInput;
-        target = target.asUGenInput;
-        output = output.asUGenInput;
-        source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
-        target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
-        output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
+		source = source.asUGenInput;
+		target = target.asUGenInput;
+		output = output.asUGenInput;
+		source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
+		target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
+		output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufNMFCrossTrigger, -1, source, target, output, timeSparsity, polyphony, continuity, iterations,  windowSize, hopSize, fftSize, fftSize, trig, blocking);
 	}
 
-    *process { |server, source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
+	*process { |server, source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        target = target.asUGenInput;
-        output = output.asUGenInput;
-        source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
-        target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
-        output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
+		source = source.asUGenInput;
+		target = target.asUGenInput;
+		output = output.asUGenInput;
+		source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
+		target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
+		output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
 
 
-        ^this.new(
+		^this.new(
 			server, nil, [output]
 		).processList(
 			[source, target, output, timeSparsity, polyphony, continuity, iterations,  windowSize, hopSize, fftSize, fftSize, 0],freeWhenDone, action
 		);
 	}
 
-    *processBlocking { |server, source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
+	*processBlocking { |server, source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        target = target.asUGenInput;
-        output = output.asUGenInput;
-        source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
-        target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
-        output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
+		source = source.asUGenInput;
+		target = target.asUGenInput;
+		output = output.asUGenInput;
+		source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
+		target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
+		output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
 
 
-        ^this.new(
+		^this.new(
 			server, nil, [output]
 		).processList(
 			[source, target, output, timeSparsity, polyphony, continuity, iterations,  windowSize, hopSize, fftSize, fftSize, 1],freeWhenDone, action

--- a/release-packaging/Classes/FluidBufNMFSeed.sc
+++ b/release-packaging/Classes/FluidBufNMFSeed.sc
@@ -2,12 +2,12 @@ FluidBufNMFSeed : FluidBufProcessor{
 
 	*kr  { |source, bases, activations, minComponents = 1, maxComponents = 200, coverage = 0.5, method = 0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-        source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
-        bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-        activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-        source = source.asUGenInput;
-        bases = bases.asUGenInput;
-        activations = activations.asUGenInput;
+		source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
+		bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
+		activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
+		source = source.asUGenInput;
+		bases = bases.asUGenInput;
+		activations = activations.asUGenInput;
 
 		^FluidProxyUgen.kr1(\FluidBufNMFSeedTrigger, -1, source, bases, activations, minComponents, maxComponents, coverage, method, windowSize, hopSize, fftSize, fftSize, trig, blocking);
 	}
@@ -15,12 +15,12 @@ FluidBufNMFSeed : FluidBufProcessor{
 
 	*process { |server, source, bases, activations, minComponents = 1, maxComponents = 200, coverage = 0.5, method = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
-        bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-        activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-        source = source.asUGenInput;
-        bases = bases.asUGenInput;
-        activations = activations.asUGenInput;
+		source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
+		bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
+		activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
+		source = source.asUGenInput;
+		bases = bases.asUGenInput;
+		activations = activations.asUGenInput;
 
 		^this.new(
 			server, nil, [bases,activations]
@@ -29,14 +29,14 @@ FluidBufNMFSeed : FluidBufProcessor{
 		)
 	}
 
-    *processBlocking { |server, source, bases, activations, minComponents = 1, maxComponents = 200, coverage = 0.5, method = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
+	*processBlocking { |server, source, bases, activations, minComponents = 1, maxComponents = 200, coverage = 0.5, method = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
-        bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-        activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-        source = source.asUGenInput;
-        bases = bases.asUGenInput;
-        activations = activations.asUGenInput;
+		source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
+		bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
+		activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
+		source = source.asUGenInput;
+		bases = bases.asUGenInput;
+		activations = activations.asUGenInput;
 
 		^this.new(
 			server, nil, [bases,activations]

--- a/release-packaging/Classes/FluidBufNoveltyFeature.sc
+++ b/release-packaging/Classes/FluidBufNoveltyFeature.sc
@@ -1,8 +1,8 @@
 FluidBufNoveltyFeature : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, algorithm = 0, kernelSize = 3, filterSize = 1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, algorithm = 0, kernelSize = 3, filterSize = 1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
 		source = source.asUGenInput;
 		features = features.asUGenInput;
@@ -18,20 +18,20 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, algorithm= 0, kernelSize = 3, filterSize = 1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action |
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, algorithm= 0, kernelSize = 3, filterSize = 1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action |
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
 		if (algorithm.isNil or: algorithm.isUGen) {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")
 			.format(algorithm).throw;
 		};
 
-        source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
@@ -40,15 +40,15 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, algorithm= 0, kernelSize = 3, filterSize = 1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action |
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, algorithm= 0, kernelSize = 3, filterSize = 1, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action |
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
 		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
 		if (algorithm.isNil or: algorithm.isUGen) {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")

--- a/release-packaging/Classes/FluidBufNoveltySlice.sc
+++ b/release-packaging/Classes/FluidBufNoveltySlice.sc
@@ -2,7 +2,7 @@ FluidBufNoveltySlice : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm = 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1 , blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
 		source = source.asUGenInput;
 		indices = indices.asUGenInput;
@@ -18,20 +18,20 @@ FluidBufNoveltySlice : FluidBufProcessor {
 
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm= 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action |
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm= 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action |
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
-        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
-	if (algorithm.isNil or: algorithm.isUGen) {
-            ("FluidBufNoveltySlice: % is not a recognised algorithm")
-            .format(algorithm).throw;
-        };
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
+		if (algorithm.isNil or: algorithm.isUGen) {
+			("FluidBufNoveltySlice: % is not a recognised algorithm")
+			.format(algorithm).throw;
+		};
 
-        source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
-        indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
+		indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [indices]
@@ -40,20 +40,20 @@ FluidBufNoveltySlice : FluidBufProcessor {
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm= 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action |
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, algorithm= 0, kernelSize = 3, threshold = 0.5, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action |
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
-        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
-	if (algorithm.isNil or: algorithm.isUGen) {
-            ("FluidBufNoveltySlice: % is not a recognised algorithm")
-            .format(algorithm).throw;
-        };
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
+		if (algorithm.isNil or: algorithm.isUGen) {
+			("FluidBufNoveltySlice: % is not a recognised algorithm")
+			.format(algorithm).throw;
+		};
 
-        source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
-        indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
+		indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [indices]

--- a/release-packaging/Classes/FluidBufOnsetFeature.sc
+++ b/release-packaging/Classes/FluidBufOnsetFeature.sc
@@ -1,35 +1,35 @@
 FluidBufOnsetFeature : FluidBufProcessor {
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, metric = 0, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, metric = 0, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
-            ("FluidBufOnsetSlice: % is not a recognised metric")
-            .format(metric).throw;
-        };
+		source = source.asUGenInput;
+		features = features.asUGenInput;
+		metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+			("FluidBufOnsetSlice: % is not a recognised metric")
+			.format(metric).throw;
+		};
 
-        source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufOnsetFeatureTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, metric, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, metric = 0, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, metric = 0, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric);
-	if (metric.isNil or: metric.isUGen) {
-            ("FluidBufOnsetSlice: % is not a recognised metric")
-            .format(metric).throw;
-        };
+		source = source.asUGenInput;
+		features = features.asUGenInput;
+		metric = FluidOnsetSlice.prSelectMetric(metric);
+		if (metric.isNil or: metric.isUGen) {
+			("FluidBufOnsetSlice: % is not a recognised metric")
+			.format(metric).throw;
+		};
 
-        source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
@@ -38,20 +38,20 @@ FluidBufOnsetFeature : FluidBufProcessor {
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, metric = 0, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1,padding = 1,  freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, metric = 0, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1,padding = 1,  freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric);
-	if (metric.isNil or: metric.isUGen) {
-            ("FluidBufOnsetSlice: % is not a recognised metric")
-            .format(metric).throw;
-        };
+		source = source.asUGenInput;
+		features = features.asUGenInput;
+		metric = FluidOnsetSlice.prSelectMetric(metric);
+		if (metric.isNil or: metric.isUGen) {
+			("FluidBufOnsetSlice: % is not a recognised metric")
+			.format(metric).throw;
+		};
 
-        source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufOnsetSlice.sc
+++ b/release-packaging/Classes/FluidBufOnsetSlice.sc
@@ -1,36 +1,36 @@
 FluidBufOnsetSlice : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
-            ("FluidBufOnsetSlice: % is not a recognised metric")
-            .format(metric).throw;
-        };
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
+		metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
+			("FluidBufOnsetSlice: % is not a recognised metric")
+			.format(metric).throw;
+		};
 
-        source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
-        indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
+		indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufOnsetSliceTrigger, -1, source, startFrame, numFrames, startChan, numChans, indices, metric, threshold, minSliceLength, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric);
-	if (metric.isNil or: metric.isUGen) {
-            ("FluidBufOnsetSlice: % is not a recognised metric")
-            .format(metric).throw;
-        };
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
+		metric = FluidOnsetSlice.prSelectMetric(metric);
+		if (metric.isNil or: metric.isUGen) {
+			("FluidBufOnsetSlice: % is not a recognised metric")
+			.format(metric).throw;
+		};
 
-        source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
-        indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
+		indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [indices]
@@ -39,20 +39,20 @@ FluidBufOnsetSlice : FluidBufProcessor {
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, metric = 0, threshold = 0.5, minSliceLength = 2, filterSize = 5, frameDelta = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
-        metric = FluidOnsetSlice.prSelectMetric(metric);
-	if (metric.isNil or: metric.isUGen) {
-            ("FluidBufOnsetSlice: % is not a recognised metric")
-            .format(metric).throw;
-        };
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
+		metric = FluidOnsetSlice.prSelectMetric(metric);
+		if (metric.isNil or: metric.isUGen) {
+			("FluidBufOnsetSlice: % is not a recognised metric")
+			.format(metric).throw;
+		};
 
-        source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
-        indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
+		indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [indices]

--- a/release-packaging/Classes/FluidBufPitch.sc
+++ b/release-packaging/Classes/FluidBufPitch.sc
@@ -1,52 +1,52 @@
 FluidBufPitch : FluidBufProcessor{
 
-    const <features=#[\pitch, \confidence];
-    classvar featuresLookup;
+	const <features=#[\pitch, \confidence];
+	classvar featuresLookup;
 
-    *initClass {
-        featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
-    }
+	*initClass {
+		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
+	}
 
-    *prWarnUnrecognised {|sym| ("WARNING: FluidBufPitch -" + sym + "is not a recognised option").postln}
+	*prWarnUnrecognised {|sym| ("WARNING: FluidBufPitch -" + sym + "is not a recognised option").postln}
 
-    *prProcessSelect {|a|
-        var bits;
-        a.asBag.countsDo{|item,count,i|
-            if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-        };
-        bits = a.collect{ |sym|
-            (featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-        }.reduce{|x,y| x | y};
-        ^bits
-    }
+	*prProcessSelect {|a|
+		var bits;
+		a.asBag.countsDo{|item,count,i|
+			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
+		};
+		bits = a.collect{ |sym|
+			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
+		}.reduce{|x,y| x | y};
+		^bits
+	}
 
 	*kr { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  select, algorithm = 2, minFreq = 20, maxFreq = 10000, unit = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
 
-        source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        ^FluidProxyUgen.kr(\FluidBufPitchTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, algorithm, minFreq, maxFreq, unit, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
+		source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
+
+		^FluidProxyUgen.kr(\FluidBufPitchTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, algorithm, minFreq, maxFreq, unit, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, algorithm = 2, minFreq = 20, maxFreq = 10000, unit = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, algorithm = 2, minFreq = 20, maxFreq = 10000, unit = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		source = source.asUGenInput;
+		features = features.asUGenInput;
 
-        source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
+		source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
@@ -55,17 +55,17 @@ FluidBufPitch : FluidBufProcessor{
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  select, algorithm = 2, minFreq = 20, maxFreq = 10000, unit = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  select, algorithm = 2, minFreq = 20, maxFreq = 10000, unit = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        features = features.asUGenInput;
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
 
-        source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
-        features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
+		source = source.asUGenInput;
+		features = features.asUGenInput;
+
+		source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
+		features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufSTFT.sc
+++ b/release-packaging/Classes/FluidBufSTFT.sc
@@ -1,38 +1,38 @@
 FluidBufSTFT : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, magnitude, phase, resynth, inverse = 0,windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 1|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, magnitude, phase, resynth, inverse = 0,windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 1|
 
-        source = source ? -1;
-        magnitude = magnitude ? -1;
-        phase = phase ? -1;
-        resynth = resynth ? - 1;
+		source = source ? -1;
+		magnitude = magnitude ? -1;
+		phase = phase ? -1;
+		resynth = resynth ? - 1;
 
-        ^FluidProxyUgen.kr(\FluidBufSTFTTrigger, -1, source, startFrame, numFrames, startChan, magnitude, phase, resynth, inverse, padding, windowSize, hopSize, fftSize, -1,  trig, blocking);
+		^FluidProxyUgen.kr(\FluidBufSTFTTrigger, -1, source, startFrame, numFrames, startChan, magnitude, phase, resynth, inverse, padding, windowSize, hopSize, fftSize, -1,  trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, magnitude, phase, resynth, inverse = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
-        source = source ? -1;
-        magnitude = magnitude ? -1;
-        phase = phase ? -1;
-        resynth = resynth ? - 1;
+		source = source ? -1;
+		magnitude = magnitude ? -1;
+		phase = phase ? -1;
+		resynth = resynth ? - 1;
 
-	    ^this.new(
-            server, nil, [magnitude,phase,resynth].select{|b| b != -1}
+		^this.new(
+			server, nil, [magnitude,phase,resynth].select{|b| b != -1}
 		).processList(
 			[source, startFrame, numFrames, startChan, magnitude, phase, resynth, inverse, padding, windowSize, hopSize, fftSize, -1,  0], freeWhenDone, action
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, magnitude, phase, resynth, inverse = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1,freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, magnitude, phase, resynth, inverse = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1,freeWhenDone = true, action|
 
-        source = source ? -1;
-        magnitude = magnitude ? -1;
-        phase = phase ? -1;
-        resynth = resynth ? - 1;
+		source = source ? -1;
+		magnitude = magnitude ? -1;
+		phase = phase ? -1;
+		resynth = resynth ? - 1;
 
-	    ^this.new(
-            server, nil, [magnitude,phase,resynth].select{|b| b != -1}
+		^this.new(
+			server, nil, [magnitude,phase,resynth].select{|b| b != -1}
 		).processList(
 			[source, startFrame, numFrames, startChan, magnitude, phase, resynth, inverse, padding, windowSize, hopSize, fftSize, -1, 1], freeWhenDone, action
 		);

--- a/release-packaging/Classes/FluidBufScale.sc
+++ b/release-packaging/Classes/FluidBufScale.sc
@@ -1,41 +1,41 @@
 FluidBufScale : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, inputLow = 0, inputHigh = 1, outputLow = 0, outputHigh = 1, clipping = 0,  trig = 1, blocking = 1|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, inputLow = 0, inputHigh = 1, outputLow = 0, outputHigh = 1, clipping = 0,  trig = 1, blocking = 1|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
 
-        ^FluidProxyUgen.kr(\FluidBufScaleTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, inputLow, inputHigh, outputLow, outputHigh, clipping, trig, blocking);
+		^FluidProxyUgen.kr(\FluidBufScaleTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, inputLow, inputHigh, outputLow, outputHigh, clipping, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, inputLow = 0, inputHigh = 1, outputLow = 0, outputHigh = 1, clipping = 0,  freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
 
-	    ^this.new(
-            server, nil, [destination]
+		^this.new(
+			server, nil, [destination]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, destination, inputLow, inputHigh, outputLow, outputHigh, clipping, 0], freeWhenDone, action
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, inputLow = 0, inputHigh = 1, outputLow = 0, outputHigh = 1, clipping = 0,  freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, inputLow = 0, inputHigh = 1, outputLow = 0, outputHigh = 1, clipping = 0,  freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
 
-	    ^this.new(
-            server, nil, [destination]
+		^this.new(
+			server, nil, [destination]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, destination, inputLow, inputHigh, outputLow, outputHigh, clipping, 1], freeWhenDone, action
 		);

--- a/release-packaging/Classes/FluidBufSelect.sc
+++ b/release-packaging/Classes/FluidBufSelect.sc
@@ -1,62 +1,62 @@
 FluidBufSelect : FluidBufProcessor {
 
-    *kr  { |source, destination, indices=#[-1], channels=#[-1], trig = 1, blocking = 1|
+	*kr  { |source, destination, indices=#[-1], channels=#[-1], trig = 1, blocking = 1|
 
-        var params;
+		var params;
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        indices = indices.asArray;
-        channels = channels.asArray;
+		indices = indices.asArray;
+		channels = channels.asArray;
 
-        indices = [indices.size] ++ indices;
-        channels = [channels.size] ++ channels;
+		indices = [indices.size] ++ indices;
+		channels = [channels.size] ++ channels;
 
-        source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
 
-        params = indices ++ channels ++ [trig, blocking]
+		params = indices ++ channels ++ [trig, blocking]
 
-        ^FluidProxyUgen.kr(\FluidBufSelectTrigger,-1, source, destination, *params);
+		^FluidProxyUgen.kr(\FluidBufSelectTrigger,-1, source, destination, *params);
 	}
 
 
 	*process { |server, source, destination, indices=#[-1], channels=#[-1], freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
 
-        indices = indices.asArray;
-        channels = channels.asArray;
+		indices = indices.asArray;
+		channels = channels.asArray;
 
 		indices = [indices.size] ++ indices;
-        channels = [channels.size] ++ channels;
+		channels = [channels.size] ++ channels;
 
-        ^this.new(server, nil, [destination]).processList([source, destination]++ indices ++ channels ++ [1], freeWhenDone, action);//NB always blocking
+		^this.new(server, nil, [destination]).processList([source, destination]++ indices ++ channels ++ [1], freeWhenDone, action);//NB always blocking
 	}
 
-   *processBlocking { |server, source, destination, indices=#[-1], channels=#[-1], freeWhenDone = true, action|
+	*processBlocking { |server, source, destination, indices=#[-1], channels=#[-1], freeWhenDone = true, action|
 
-       source = source.asUGenInput;
-       destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-       source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
-       destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
 
-       indices = indices.asArray;
-       channels = channels.asArray;
+		indices = indices.asArray;
+		channels = channels.asArray;
 
-       indices = [indices.size] ++ indices;
-       channels = [channels.size] ++ channels;
+		indices = [indices.size] ++ indices;
+		channels = [channels.size] ++ channels;
 
 
-       ^this.new(
-           server, nil, [destination]
-       ).processList([source, destination]++ indices ++ channels ++ [1], freeWhenDone, action);//NB always blocking
+		^this.new(
+			server, nil, [destination]
+		).processList([source, destination]++ indices ++ channels ++ [1], freeWhenDone, action);//NB always blocking
 	}
 }
 FluidBufSelectTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufSelectEvery.sc
+++ b/release-packaging/Classes/FluidBufSelectEvery.sc
@@ -1,41 +1,41 @@
 FluidBufSelectEvery : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, frameHop = 1, chanHop = 1, trig = 1, blocking = 1|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, frameHop = 1, chanHop = 1, trig = 1, blocking = 1|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
 
-        ^FluidProxyUgen.kr(\FluidBufSelectEveryTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, frameHop, chanHop, trig, blocking);
+		^FluidProxyUgen.kr(\FluidBufSelectEveryTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, frameHop, chanHop, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, frameHop = 1, chanHop = 1, freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
 
-	    ^this.new(
-            server, nil, [destination]
+		^this.new(
+			server, nil, [destination]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, destination, frameHop, chanHop, 0], freeWhenDone, action
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, frameHop = 1, chanHop = 1, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, frameHop = 1, chanHop = 1, freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
+		source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
 
-	    ^this.new(
-            server, nil, [destination]
+		^this.new(
+			server, nil, [destination]
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, destination, frameHop, chanHop, 1], freeWhenDone, action
 		);

--- a/release-packaging/Classes/FluidBufSines.sc
+++ b/release-packaging/Classes/FluidBufSines.sc
@@ -1,27 +1,27 @@
 FluidBufSines : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, sines = -1, residual = -1, bandwidth = 76, detectionThreshold = -96, birthLowThreshold = -24, birthHighThreshold = -60, minTrackLen = 15, trackingMethod = 0, trackMagRange = 15, trackFreqRange = 50, trackProb = 0.5, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, sines = -1, residual = -1, bandwidth = 76, detectionThreshold = -96, birthLowThreshold = -24, birthHighThreshold = -60, minTrackLen = 15, trackingMethod = 0, trackMagRange = 15, trackFreqRange = 50, trackProb = 0.5, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        sines = sines !? {sines.asUGenInput} ?? {-1};
-        residual = residual !? {residual.asUGenInput} ?? {-1};
+		source = source.asUGenInput;
+		sines = sines !? {sines.asUGenInput} ?? {-1};
+		residual = residual !? {residual.asUGenInput} ?? {-1};
 
-        source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
+		source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
 
 		^FluidProxyUgen.multiNew(\FluidBufSinesTrigger, -1, source, startFrame, numFrames, startChan, numChans, sines, residual, bandwidth, detectionThreshold,birthLowThreshold, birthHighThreshold, minTrackLen, trackingMethod, trackMagRange, trackFreqRange, trackProb, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, sines = -1, residual = -1, bandwidth = 76, detectionThreshold = -96, birthLowThreshold = -24, birthHighThreshold = -60, minTrackLen = 15, trackingMethod = 0, trackMagRange = 15, trackFreqRange = 50, trackProb = 0.5, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, sines = -1, residual = -1, bandwidth = 76, detectionThreshold = -96, birthLowThreshold = -24, birthHighThreshold = -60, minTrackLen = 15, trackingMethod = 0, trackMagRange = 15, trackFreqRange = 50, trackProb = 0.5, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        sines = sines !? {sines.asUGenInput} ?? {-1};
-        residual = residual !? {residual.asUGenInput} ?? {-1};
+		source = source.asUGenInput;
+		sines = sines !? {sines.asUGenInput} ?? {-1};
+		residual = residual !? {residual.asUGenInput} ?? {-1};
 
-        source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
+		source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
 
 		^this.new(
 			server, nil, [sines, residual].select{|x| x!= -1}
@@ -30,15 +30,15 @@ FluidBufSines : FluidBufProcessor {
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, sines = -1, residual = -1, bandwidth = 76, detectionThreshold = -96, birthLowThreshold = -24, birthHighThreshold = -60, minTrackLen = 15, trackingMethod = 0, trackMagRange = 15, trackFreqRange = 50, trackProb = 0.5, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, sines = -1, residual = -1, bandwidth = 76, detectionThreshold = -96, birthLowThreshold = -24, birthHighThreshold = -60, minTrackLen = 15, trackingMethod = 0, trackMagRange = 15, trackFreqRange = 50, trackProb = 0.5, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-        var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
+		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-        source = source.asUGenInput;
-        sines = sines !? {sines.asUGenInput} ?? {-1};
-        residual = residual !? {residual.asUGenInput} ?? {-1};
+		source = source.asUGenInput;
+		sines = sines !? {sines.asUGenInput} ?? {-1};
+		residual = residual !? {residual.asUGenInput} ?? {-1};
 
-        source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
+		source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
 
 		^this.new(
 			server, nil, [sines, residual].select{|x| x!= -1}

--- a/release-packaging/Classes/FluidBufSpectralShape.sc
+++ b/release-packaging/Classes/FluidBufSpectralShape.sc
@@ -1,9 +1,9 @@
 FluidBufSpectralShape : FluidBufProcessor {
 
-    *kr { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
+	*kr { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
+		var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
 
 		source = source.asUGenInput;
 		features = features.asUGenInput;
@@ -16,10 +16,10 @@ FluidBufSpectralShape : FluidBufProcessor {
 
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
+		var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
 
 		source = source.asUGenInput;
 		features = features.asUGenInput;
@@ -30,14 +30,14 @@ FluidBufSpectralShape : FluidBufProcessor {
 		^this.new(
 			server, nil, [features]
 		).processList(
-			 [source, startFrame, numFrames, startChan, numChans, features, padding, selectbits,  minFreq, maxFreq, rolloffPercent, unit, power, windowSize, hopSize, fftSize, maxFFTSize, 0], freeWhenDone, action
+			[source, startFrame, numFrames, startChan, numChans, features, padding, selectbits,  minFreq, maxFreq, rolloffPercent, unit, power, windowSize, hopSize, fftSize, maxFFTSize, 0], freeWhenDone, action
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-        var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
+		var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
 
 		source = source.asUGenInput;
 		features = features.asUGenInput;
@@ -48,7 +48,7 @@ FluidBufSpectralShape : FluidBufProcessor {
 		^this.new(
 			server, nil, [features]
 		).processList(
-			 [source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, minFreq, maxFreq, rolloffPercent, unit, power, windowSize, hopSize, fftSize, maxFFTSize, 1], freeWhenDone, action
+			[source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, minFreq, maxFreq, rolloffPercent, unit, power, windowSize, hopSize, fftSize, maxFFTSize, 1], freeWhenDone, action
 		);
 	}
 }

--- a/release-packaging/Classes/FluidBufStats.sc
+++ b/release-packaging/Classes/FluidBufStats.sc
@@ -1,49 +1,49 @@
 FluidBufStats : FluidBufProcessor {
 
-    const <stats=#[\mean,\std,\skewness,\kurtosis,\low,\mid,\high];
-    classvar statslookup;
+	const <stats=#[\mean,\std,\skewness,\kurtosis,\low,\mid,\high];
+	classvar statslookup;
 
-    *prWarnUnrecognised {|sym| ("WARNING: FluidBufStats -" + sym + "is not a recognised option").postln}
+	*prWarnUnrecognised {|sym| ("WARNING: FluidBufStats -" + sym + "is not a recognised option").postln}
 
-    *prProcessSelect {|a|
-        var bits;
-        a.asBag.countsDo{|item,count,i|
-            if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-        };
-        bits = a.collect{ |sym|
-            (statslookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-        }.reduce{|x,y| x | y};
-        ^bits
-    }
+	*prProcessSelect {|a|
+		var bits;
+		a.asBag.countsDo{|item,count,i|
+			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
+		};
+		bits = a.collect{ |sym|
+			(statslookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
+		}.reduce{|x,y| x | y};
+		^bits
+	}
 
-    *initClass {
-        statslookup = Dictionary.with(*this.stats.collect{|x,i| x->(1<<i)});
-    }
+	*initClass {
+		statslookup = Dictionary.with(*this.stats.collect{|x,i| x->(1<<i)});
+	}
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, stats, select, numDerivs = 0, low = 0, middle = 50, high = 100, outliersCutoff = -1, weights, trig = 1, blocking = 0|
 
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
-        source = source.asUGenInput;
-        stats = stats.asUGenInput;
-        weights = weights.asUGenInput;
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
+		source = source.asUGenInput;
+		stats = stats.asUGenInput;
+		weights = weights.asUGenInput;
 
-        source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
-        stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
-        weights = weights ? -1;
+		source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
+		stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
+		weights = weights ? -1;
 
 		^FluidProxyUgen.kr(\FluidBufStatsTrigger, -1, source, startFrame, numFrames, startChan, numChans, stats, selectbits, numDerivs, low, middle, high, outliersCutoff, weights, trig, blocking);
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, stats, select, numDerivs = 0, low = 0, middle = 50, high = 100, outliersCutoff = -1, weights, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, stats, select, numDerivs = 0, low = 0, middle = 50, high = 100, outliersCutoff = -1, weights, freeWhenDone = true, action|
 
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
-        source = source.asUGenInput;
-        stats = stats.asUGenInput;
-        weights = weights.asUGenInput;
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
+		source = source.asUGenInput;
+		stats = stats.asUGenInput;
+		weights = weights.asUGenInput;
 
-        source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
-        stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
-        weights = weights ? -1;
+		source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
+		stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
+		weights = weights ? -1;
 
 		^this.new(
 			server, nil, [stats]
@@ -52,15 +52,15 @@ FluidBufStats : FluidBufProcessor {
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, stats, select numDerivs = 0, low = 0, middle = 50, high = 100, outliersCutoff = -1, weights, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, stats, select numDerivs = 0, low = 0, middle = 50, high = 100, outliersCutoff = -1, weights, freeWhenDone = true, action|
 
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
-        source = source.asUGenInput;
-        stats = stats.asUGenInput;
-        weights = weights.asUGenInput;
-        source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
-        stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
-        weights = weights ? -1;
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
+		source = source.asUGenInput;
+		stats = stats.asUGenInput;
+		weights = weights.asUGenInput;
+		source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
+		stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
+		weights = weights ? -1;
 
 		^this.new(
 			server, nil, [stats]

--- a/release-packaging/Classes/FluidBufThreadDemo.sc
+++ b/release-packaging/Classes/FluidBufThreadDemo.sc
@@ -2,33 +2,33 @@ FluidBufThreadDemo : FluidBufProcessor{
 
 	*kr  {|result, time, trig = 1, blocking = 0|
 
-        result = result.asUGenInput;
-        result.isNil.if {this.class.name+":  Invalid output buffer".throw};
+		result = result.asUGenInput;
+		result.isNil.if {this.class.name+":  Invalid output buffer".throw};
 
-        ^FluidProxyUgen.kr(\FluidBufThreadDemoTrigger, -1, result, time, trig, blocking);
-	 }
+		^FluidProxyUgen.kr(\FluidBufThreadDemoTrigger, -1, result, time, trig, blocking);
+	}
 
-    *process { |server, result, time = 1000, freeWhenDone = true, action|
+	*process { |server, result, time = 1000, freeWhenDone = true, action|
 
 
-        result ?? {this.class.name+":  Invalid output buffer".throw};
+		result ?? {this.class.name+":  Invalid output buffer".throw};
 
 		^this.new(
 			server, nil, [result]
 		).processList(
 			[result.asUGenInput, time, 0], freeWhenDone, action
 		);
-    }
+	}
 
-    *processBlocking { |server, result, time = 1000, freeWhenDone = true, action|
+	*processBlocking { |server, result, time = 1000, freeWhenDone = true, action|
 
-        result ?? {this.class.name+":  Invalid output buffer".throw};
+		result ?? {this.class.name+":  Invalid output buffer".throw};
 
 		^this.new(
 			server, nil, [result]
 		).processList(
 			[result.asUGenInput, time, 1], freeWhenDone, action
 		);
-    }
+	}
 }
 FluidBufThreadDemoTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufThresh.sc
+++ b/release-packaging/Classes/FluidBufThresh.sc
@@ -1,42 +1,42 @@
 FluidBufThresh : FluidBufProcessor {
 
-    *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, threshold = 0, trig = 1, blocking = 1|
-        
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, threshold = 0, trig = 1, blocking = 1|
 
-        source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
-        
-        ^FluidProxyUgen.kr(\FluidBufThreshTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, threshold, trig, blocking);
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
+
+		source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
+
+		^FluidProxyUgen.kr(\FluidBufThreshTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, threshold, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1,  destination, threshold = 0, freeWhenDone = true,  action|
-        
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
 
-        source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
-        
-	    ^this.new(
-            server, nil, [destination],
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
+
+		source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
+
+		^this.new(
+			server, nil, [destination],
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, destination, threshold, 0], freeWhenDone, action
 		);
 
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1,  destination, threshold = 0, freeWhenDone = true, action|
-        
-        source = source.asUGenInput;
-        destination = destination.asUGenInput;
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1,  destination, threshold = 0, freeWhenDone = true, action|
 
-        source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
-        destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
-        
-	    ^this.new(
-            server, nil, [destination],
+		source = source.asUGenInput;
+		destination = destination.asUGenInput;
+
+		source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
+		destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
+
+		^this.new(
+			server, nil, [destination],
 		).processList(
 			[source, startFrame, numFrames, startChan, numChans, destination, threshold, 1], freeWhenDone, action
 		);

--- a/release-packaging/Classes/FluidBufTransientSlice.sc
+++ b/release-packaging/Classes/FluidBufTransientSlice.sc
@@ -2,41 +2,41 @@ FluidBufTransientSlice : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, minSliceLength = 1000, trig = 1, blocking = 0|
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
 
-        source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-        indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
+		indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
 
 		^FluidProxyUgen.kr(this.objectClassName++\Trigger, -1, source, startFrame, numFrames, startChan, numChans, indices, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, minSliceLength, trig, blocking);
 	}
 
-    *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, minSliceLength = 1000, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, minSliceLength = 1000, freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
 
-        source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-        indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
+		indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
 
-        ^this.new(
+		^this.new(
 			server, nil,[indices]
-        ).processList([source, startFrame, numFrames, startChan, numChans, indices, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, minSliceLength,0], freeWhenDone, action
-        );
-    }
+		).processList([source, startFrame, numFrames, startChan, numChans, indices, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, minSliceLength,0], freeWhenDone, action
+		);
+	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, minSliceLength = 1000, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, minSliceLength = 1000, freeWhenDone = true, action|
 
-        source = source.asUGenInput;
-        indices = indices.asUGenInput;
+		source = source.asUGenInput;
+		indices = indices.asUGenInput;
 
-        source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-        indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
+		indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
 
-        ^this.new(
+		^this.new(
 			server, nil,[indices]
-        ).processList([source, startFrame, numFrames, startChan, numChans, indices, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, minSliceLength,1], freeWhenDone, action
-        );
-    }
+		).processList([source, startFrame, numFrames, startChan, numChans, indices, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, minSliceLength,1], freeWhenDone, action
+		);
+	}
 }
 FluidBufTransientSliceTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidBufTransients.sc
+++ b/release-packaging/Classes/FluidBufTransients.sc
@@ -1,23 +1,23 @@
 FluidBufTransients : FluidBufProcessor {
 
-	 *kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, trig = 1, blocking = 0|
+	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, trig = 1, blocking = 0|
 
- 		source = source.asUGenInput;
- 		transients = transients ? -1;
- 		residual = residual ? -1;
+		source = source.asUGenInput;
+		transients = transients ? -1;
+		residual = residual ? -1;
 
- 		source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
+		source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
 
-        ^FluidProxyUgen.kr(\FluidBufTransientsTrigger, -1, source, startFrame, numFrames, startChan, numChans, transients, residual, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, trig, blocking);
+		^FluidProxyUgen.kr(\FluidBufTransientsTrigger, -1, source, startFrame, numFrames, startChan, numChans, transients, residual, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, trig, blocking);
 	}
 
-	 *process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, freeWhenDone = true, action|
+	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, freeWhenDone = true, action|
 
- 		source = source.asUGenInput;
- 		transients = transients ? -1;
- 		residual = residual ? -1;
+		source = source.asUGenInput;
+		transients = transients ? -1;
+		residual = residual ? -1;
 
- 		source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
+		source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
 
 		^this.new(
 			server, nil,[transients, residual].select{|x| x!= -1}
@@ -26,19 +26,19 @@ FluidBufTransients : FluidBufProcessor {
 		);
 	}
 
-    *processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, freeWhenDone = true, action|
+	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, freeWhenDone = true, action|
 
-       source = source.asUGenInput;
-       transients = transients ? -1;
-       residual = residual ? -1;
+		source = source.asUGenInput;
+		transients = transients ? -1;
+		residual = residual ? -1;
 
-       source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
+		source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
 
-       ^this.new(
-           server, nil,[transients, residual].select{|x| x!= -1}
-       ).processList(
-           [source, startFrame, numFrames, startChan, numChans, transients, residual, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength,1],freeWhenDone = true,action
-       );
-   }
+		^this.new(
+			server, nil,[transients, residual].select{|x| x!= -1}
+		).processList(
+			[source, startFrame, numFrames, startChan, numChans, transients, residual, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength,1],freeWhenDone = true,action
+		);
+	}
 }
 FluidBufTransientsTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidChroma.sc
+++ b/release-packaging/Classes/FluidChroma.sc
@@ -1,9 +1,9 @@
 FluidChroma : FluidRTMultiOutUGen {
 
 	*kr { arg in = 0, numChroma = 12, ref = 440, normalize = 0, minFreq = 0, maxFreq = -1, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1, maxNumChroma;
-        
-        maxNumChroma = maxNumChroma ? numChroma; 
-        
+
+		maxNumChroma = maxNumChroma ? numChroma;
+
 		^this.multiNew('control', in.asAudioRateInput(this), numChroma, maxNumChroma, ref, normalize, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize);
 	}
 

--- a/release-packaging/Classes/FluidDataSet.sc
+++ b/release-packaging/Classes/FluidDataSet.sc
@@ -1,72 +1,72 @@
 
 FluidDataSet : FluidDataObject
 {
-    *new{|server| ^super.new(server) }
+	*new{|server| ^super.new(server) }
 
-    addPointMsg{|identifier,buffer|
-        buffer = this.prEncodeBuffer(buffer);
-        ^this.prMakeMsg(\addPoint,id,identifier.asSymbol,buffer);
-    }
-
-	addPoint{|identifier, buffer, action|
-      actions[\addPoint] = [nil,action];
-	  this.prSendMsg(this.addPointMsg(identifier,buffer));
+	addPointMsg{|identifier,buffer|
+		buffer = this.prEncodeBuffer(buffer);
+		^this.prMakeMsg(\addPoint,id,identifier.asSymbol,buffer);
 	}
 
-    getPointMsg{|identifier,buffer|
-        buffer = this.prEncodeBuffer(buffer);
-        ^this.prMakeMsg(\getPoint,id,identifier.asSymbol,buffer,["/b_query",buffer.asUGenInput]);
-    }
+	addPoint{|identifier, buffer, action|
+		actions[\addPoint] = [nil,action];
+		this.prSendMsg(this.addPointMsg(identifier,buffer));
+	}
 
-    getPoint{|identifier, buffer, action|
-      actions[\getPoint] = [nil,action];
-      this.prSendMsg(this.getPointMsg(identifier,buffer));
-    }
+	getPointMsg{|identifier,buffer|
+		buffer = this.prEncodeBuffer(buffer);
+		^this.prMakeMsg(\getPoint,id,identifier.asSymbol,buffer,["/b_query",buffer.asUGenInput]);
+	}
 
-    updatePointMsg{|identifier,buffer|
-        buffer = this.prEncodeBuffer(buffer);
-        ^this.prMakeMsg(\updatePoint,id,identifier.asSymbol,buffer,["/b_query",buffer.asUGenInput]);
-    }
+	getPoint{|identifier, buffer, action|
+		actions[\getPoint] = [nil,action];
+		this.prSendMsg(this.getPointMsg(identifier,buffer));
+	}
 
-    updatePoint{|identifier, buffer, action|
-      actions[\updatePoint] = [nil,action];
-      this.prSendMsg(this.updatePointMsg(identifier,buffer));
-    }
+	updatePointMsg{|identifier,buffer|
+		buffer = this.prEncodeBuffer(buffer);
+		^this.prMakeMsg(\updatePoint,id,identifier.asSymbol,buffer,["/b_query",buffer.asUGenInput]);
+	}
 
-    deletePointMsg{|identifier| ^this.prMakeMsg(\deletePoint,id,identifier.asSymbol);}
+	updatePoint{|identifier, buffer, action|
+		actions[\updatePoint] = [nil,action];
+		this.prSendMsg(this.updatePointMsg(identifier,buffer));
+	}
 
-    deletePoint{|identifier, action|
-      actions[\deletePoint] = [nil,action];
-      this.prSendMsg(this.deletePointMsg(identifier));
-    }
+	deletePointMsg{|identifier| ^this.prMakeMsg(\deletePoint,id,identifier.asSymbol);}
 
-    setPointMsg{|identifier,buffer|
-        buffer = this.prEncodeBuffer(buffer);
-        ^this.prMakeMsg(\setPoint,id,identifier.asSymbol,buffer,["/b_query",buffer.asUGenInput]);
-    }
+	deletePoint{|identifier, action|
+		actions[\deletePoint] = [nil,action];
+		this.prSendMsg(this.deletePointMsg(identifier));
+	}
+
+	setPointMsg{|identifier,buffer|
+		buffer = this.prEncodeBuffer(buffer);
+		^this.prMakeMsg(\setPoint,id,identifier.asSymbol,buffer,["/b_query",buffer.asUGenInput]);
+	}
 
 	setPoint{|identifier, buffer, action|
-      actions[\setPoint] = [nil,action];
-	  this.prSendMsg(this.setPointMsg(identifier,buffer));
+		actions[\setPoint] = [nil,action];
+		this.prSendMsg(this.setPointMsg(identifier,buffer));
 	}
 
 	clearMsg { ^this.prMakeMsg(\clear,id); }
 
-    clear { |action|
-      actions[\clear] = [nil,action];
-	  this.prSendMsg(this.clearMsg);
+	clear { |action|
+		actions[\clear] = [nil,action];
+		this.prSendMsg(this.clearMsg);
 	}
 
-    mergeMsg{|sourceDataSet, overwrite = 0|
-        ^this.prMakeMsg(\merge,id,sourceDataSet.asUGenInput,overwrite);
-    }
+	mergeMsg{|sourceDataSet, overwrite = 0|
+		^this.prMakeMsg(\merge,id,sourceDataSet.asUGenInput,overwrite);
+	}
 
 	merge{|sourceDataSet, overwrite = 0, action|
-        actions[\merge] = [nil,action];
+		actions[\merge] = [nil,action];
 		this.prSendMsg(this.mergeMsg(sourceDataSet,overwrite));
 	}
 
-    printMsg { ^this.prMakeMsg(\print,id); }
+	printMsg { ^this.prMakeMsg(\print,id); }
 
 	print { |action=(postResponse)|
 		actions[\print] = [string(FluidMessageResponse,_,_),action];
@@ -74,31 +74,31 @@ FluidDataSet : FluidDataObject
 	}
 
 	toBufferMsg{|buffer, transpose = 0, labelSet|
-        buffer = this.prEncodeBuffer(buffer);
-       ^this.prMakeMsg(\toBuffer, id, buffer, transpose, labelSet.asUGenInput,["/b_query",buffer.asUGenInput]);
-    }
+		buffer = this.prEncodeBuffer(buffer);
+		^this.prMakeMsg(\toBuffer, id, buffer, transpose, labelSet.asUGenInput,["/b_query",buffer.asUGenInput]);
+	}
 
 	toBuffer{|buffer, transpose = 0, labelSet, action|
-      actions[\toBuffer] = [nil,action];
+		actions[\toBuffer] = [nil,action];
 		this.prSendMsg(this.toBufferMsg(buffer, transpose, labelSet));
 	}
 
 	fromBufferMsg{|buffer, transpose = 0, labelSet|
-        buffer = this.prEncodeBuffer(buffer);
-       ^this.prMakeMsg(\fromBuffer, id, buffer, transpose, labelSet.asUGenInput,["/b_query",buffer.asUGenInput]);
-    }
+		buffer = this.prEncodeBuffer(buffer);
+		^this.prMakeMsg(\fromBuffer, id, buffer, transpose, labelSet.asUGenInput,["/b_query",buffer.asUGenInput]);
+	}
 
 	fromBuffer{|buffer, transpose = 0, labelSet, action|
-      actions[\fromBuffer] = [nil,action];
+		actions[\fromBuffer] = [nil,action];
 		this.prSendMsg(this.fromBufferMsg(buffer, transpose, labelSet));
 	}
 
 	getIdsMsg{|labelSet|
-        ^this.prMakeMsg(\getIds, id, labelSet.asUGenInput);
-    }
+		^this.prMakeMsg(\getIds, id, labelSet.asUGenInput);
+	}
 
 	getIds{|labelSet, action|
-      actions[\getIds] = [nil,action];
-	  this.prSendMsg(this.getIdsMsg(labelSet));
+		actions[\getIds] = [nil,action];
+		this.prSendMsg(this.getIdsMsg(labelSet));
 	}
 }

--- a/release-packaging/Classes/FluidDataSetQuery.sc
+++ b/release-packaging/Classes/FluidDataSetQuery.sc
@@ -1,85 +1,84 @@
-
 FluidDataSetQuery : FluidDataObject {
-    *new{|server| ^super.new(server) }
+	*new{|server| ^super.new(server) }
 
-    addColumnMsg { |column|
-        ^this.prMakeMsg(\addColumn,id,column);
-    }
-
-	addColumn{|column, action|
-        actions[\addColumn] = [nil,action];
-        this.prSendMsg(this.addColumnMsg(column));
+	addColumnMsg { |column|
+		^this.prMakeMsg(\addColumn,id,column);
 	}
 
-    addRangeMsg{|start,count|
-        ^this.prMakeMsg(\addRange,id,start,count);
-    }
+	addColumn{|column, action|
+		actions[\addColumn] = [nil,action];
+		this.prSendMsg(this.addColumnMsg(column));
+	}
+
+	addRangeMsg{|start,count|
+		^this.prMakeMsg(\addRange,id,start,count);
+	}
 
 	addRange{|start, count, action|
-        actions[\addRange] = [nil, action];
+		actions[\addRange] = [nil, action];
 		this.prSendMsg(this.addRangeMsg(start, count));
 	}
 
-    filterMsg{|column, condition, value, action|
-        ^this.prMakeMsg(\filter,id,column,condition.asSymbol,value);
-    }
+	filterMsg{|column, condition, value, action|
+		^this.prMakeMsg(\filter,id,column,condition.asSymbol,value);
+	}
 
 	filter{|column, condition, value, action|
-        actions[\filter] = [nil, action];
+		actions[\filter] = [nil, action];
 		this.prSendMsg(this.filterMsg(column, condition, value));
 	}
 
-    andMsg{ |column, condition, value|
-        ^this.prMakeMsg(\and,id,column, condition.asSymbol, value);
-    }
+	andMsg{ |column, condition, value|
+		^this.prMakeMsg(\and,id,column, condition.asSymbol, value);
+	}
 
 	and{|column, condition, value, action|
-        actions[\and] = [nil, action];
+		actions[\and] = [nil, action];
 		this.prSendMsg(this.andMsg(column,condition,value));
 	}
 
-    orMsg{|column, condition, value|
-        ^this.prMakeMsg(\or,id,column, condition.asSymbol, value)
-    }
+	orMsg{|column, condition, value|
+		^this.prMakeMsg(\or,id,column, condition.asSymbol, value)
+	}
 
 	or{|column, condition, value, action|
-        actions[\or] = [nil,action];
+		actions[\or] = [nil,action];
 		this.prSendMsg(this.orMsg(column, condition, value));
 	}
 
-    clearMsg{
-        ^this.prMakeMsg(\clear,id);
-    }
+	clearMsg{
+		^this.prMakeMsg(\clear,id);
+	}
 
 	clear{|action|
-        actions[\clear] = [nil, action];
+		actions[\clear] = [nil, action];
 		this.prSendMsg(this.clearMsg);
 	}
 
-    limitMsg{|rows|
-        ^this.prMakeMsg(\limit,id,rows);
-    }
+	limitMsg{|rows|
+		^this.prMakeMsg(\limit,id,rows);
+	}
 
 	limit{|rows, action|
-        actions[\limit] = [nil,action];
+		actions[\limit] = [nil,action];
 		this.prSendMsg(this.limitMsg(rows));
 	}
 
-    transformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\transform,id,sourceDataSet.id,destDataSet.id);
-    }
+	transformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\transform,id,sourceDataSet.id,destDataSet.id);
+	}
 
-    transform{|sourceDataSet, destDataSet, action|
-        actions[\transform] = [nil,action];
-        this.prSendMsg(this.transformMsg(sourceDataSet,destDataSet));
-    }
+	transform{|sourceDataSet, destDataSet, action|
+		actions[\transform] = [nil,action];
+		this.prSendMsg(this.transformMsg(sourceDataSet,destDataSet));
+	}
 
-    transformJoinMsg{|source1DataSet, source2DataSet, destDataSet|
-        ^this.prMakeMsg(\transformJoin,id,source1DataSet.id, source2DataSet.id, destDataSet.id);
-    }
+	transformJoinMsg{|source1DataSet, source2DataSet, destDataSet|
+		^this.prMakeMsg(\transformJoin,id,source1DataSet.id, source2DataSet.id, destDataSet.id);
+	}
 
 	transformJoin{|source1DataSet, source2DataSet, destDataSet, action|
-        actions[\transformJoin] = [nil,action];
-        this.prSendMsg(this.transformJoinMsg(source1DataSet, source2DataSet, destDataSet));
-    }
+		actions[\transformJoin] = [nil,action];
+		this.prSendMsg(this.transformJoinMsg(source1DataSet, source2DataSet, destDataSet));
+	}
 }

--- a/release-packaging/Classes/FluidDataSetWr.sc
+++ b/release-packaging/Classes/FluidDataSetWr.sc
@@ -1,15 +1,15 @@
 FluidDataSetWr : FluidBufProcessor {
 	*kr  { |dataset,idPrefix = "", idNumber = 0,buf, trig=1, blocking = 1|
-        var args;
-        buf ?? {(this.class.name ++ ": No input buffer provided").error};
-        
-        idNumber = idNumber !? {[2,1,idNumber.asInteger.asUGenInput]} ?? {[2,0,0]};
-        idPrefix = idPrefix !? {[idPrefix.asString.size] ++ idPrefix.asString.ascii} ?? {0};
+		var args;
+		buf ?? {(this.class.name ++ ": No input buffer provided").error};
 
-        args = [-1] ++ dataset.asUGenInput ++idPrefix ++ idNumber ++ buf.asUGenInput ++  trig ++ blocking;
+		idNumber = idNumber !? {[2,1,idNumber.asInteger.asUGenInput]} ?? {[2,0,0]};
+		idPrefix = idPrefix !? {[idPrefix.asString.size] ++ idPrefix.asString.ascii} ?? {0};
 
-        ^FluidProxyUgen.kr(\FluidDataSetWrTrigger,*args);
+		args = [-1] ++ dataset.asUGenInput ++idPrefix ++ idNumber ++ buf.asUGenInput ++  trig ++ blocking;
+
+		^FluidProxyUgen.kr(\FluidDataSetWrTrigger,*args);
 	}
 }
 
-FluidDataSetWrTrigger : FluidProxyUgen {} 
+FluidDataSetWrTrigger : FluidProxyUgen {}

--- a/release-packaging/Classes/FluidGrid.sc
+++ b/release-packaging/Classes/FluidGrid.sc
@@ -2,20 +2,20 @@ FluidGrid : FluidModelObject {
 	var <>oversample, <>extent, <>axis;
 	*new {|server, oversample = 1, extent = 0, axis = 0|
 		^super.new(server,[oversample, extent, axis])
-        .oversample_(oversample).extent_(extent).axis_(axis);
+		.oversample_(oversample).extent_(extent).axis_(axis);
 	}
 
-    prGetParams{
-        ^[this.oversample, this.extent, this.axis];
-    }
+	prGetParams{
+		^[this.oversample, this.extent, this.axis];
+	}
 
 	fitTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\fitTransform,id, sourceDataSet.id,  destDataSet.id);
-    }
+		^this.prMakeMsg(\fitTransform,id, sourceDataSet.id,  destDataSet.id);
+	}
 
 	fitTransform{|sourceDataSet, destDataSet, action|
-        actions[\fitTransform] = [nil,action];
-        this.fitTransformMsg(sourceDataSet,destDataSet);
+		actions[\fitTransform] = [nil,action];
+		this.fitTransformMsg(sourceDataSet,destDataSet);
 		this.prSendMsg(this.fitTransformMsg(sourceDataSet,destDataSet));
 	}
 

--- a/release-packaging/Classes/FluidHPSS.sc
+++ b/release-packaging/Classes/FluidHPSS.sc
@@ -1,9 +1,9 @@
 FluidHPSS : FluidRTMultiOutUGen {
 	*ar { arg in = 0, harmFilterSize=17, percFilterSize = 31, maskingMode=0, harmThreshFreq1 = 0.1, harmThreshAmp1 = 0, harmThreshFreq2 = 0.5, harmThreshAmp2 = 0, percThreshFreq1 = 0.1, percThreshAmp1 = 0, percThreshFreq2 = 0.5, percThreshAmp2 = 0, windowSize= 1024, hopSize= -1, fftSize= -1, maxFFTSize = -1, maxHarmFilterSize, maxPercFilterSize;
-        
-        maxHarmFilterSize = maxHarmFilterSize ? harmFilterSize; 
-        maxPercFilterSize = maxPercFilterSize ? percFilterSize; 
-                
+
+		maxHarmFilterSize = maxHarmFilterSize ? harmFilterSize;
+		maxPercFilterSize = maxPercFilterSize ? percFilterSize;
+
 		^this.multiNew('audio', in.asAudioRateInput(this), harmFilterSize, maxHarmFilterSize, percFilterSize, maxPercFilterSize, maskingMode, harmThreshFreq1, harmThreshAmp1, harmThreshFreq2, harmThreshAmp2, percThreshFreq1, percThreshAmp1, percThreshFreq2, percThreshAmp2, windowSize, hopSize, fftSize, maxFFTSize)
 	}
 	init { arg ... theInputs;
@@ -15,16 +15,16 @@ FluidHPSS : FluidRTMultiOutUGen {
 		];
 		^channels
 	}
-		checkInputs {
+	checkInputs {
 		if(inputs.at(17).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
-			};
+		};
 		if(inputs.at(2).rate != 'scalar') {
 			^(": maxHarmFilterSize cannot be modulated.");
-			};
+		};
 		if(inputs.at(4).rate != 'scalar') {
 			^(": maxPercFilterSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidKDTree.sc
+++ b/release-packaging/Classes/FluidKDTree.sc
@@ -1,69 +1,69 @@
 FluidKDTree : FluidModelObject
- {
+{
 
-    var neighbours,radius;
+	var neighbours,radius;
 
-    *new{ |server, numNeighbours = 1, radius = 0|
-        ^super.new(server,[numNeighbours,radius ? -1])
-        .numNeighbours_(numNeighbours)
-        .radius_(radius);
-    }
+	*new{ |server, numNeighbours = 1, radius = 0|
+		^super.new(server,[numNeighbours,radius ? -1])
+		.numNeighbours_(numNeighbours)
+		.radius_(radius);
+	}
 
-    numNeighbours_{|k|neighbours = k.asInteger; }
-    numNeighbours{ ^neighbours; }
+	numNeighbours_{|k|neighbours = k.asInteger; }
+	numNeighbours{ ^neighbours; }
 
-    radius_{|r| radius = r.asUGenInput;}
-    radius{ ^radius; }
+	radius_{|r| radius = r.asUGenInput;}
+	radius{ ^radius; }
 
-    prGetParams{^[this.id, this.numNeighbours,this.radius];}
+	prGetParams{^[this.id, this.numNeighbours,this.radius];}
 
-    fitMsg{ |dataSet| ^this.prMakeMsg(\fit,this.id,dataSet.id);}
+	fitMsg{ |dataSet| ^this.prMakeMsg(\fit,this.id,dataSet.id);}
 
 	fit{|dataSet,action|
-        actions[\fit] = [nil,action];
+		actions[\fit] = [nil,action];
 		this.prSendMsg(this.fitMsg(dataSet));
 	}
 
-    kNearestMsg{|buffer,k|
-        k !?
-        {^this.prMakeMsg(\kNearest,id,this.prEncodeBuffer(buffer),k);}
-        ??
-        {^this.prMakeMsg(\kNearest,id,this.prEncodeBuffer(buffer));}
-    }
+	kNearestMsg{|buffer,k|
+		k !?
+		{^this.prMakeMsg(\kNearest,id,this.prEncodeBuffer(buffer),k);}
+		??
+		{^this.prMakeMsg(\kNearest,id,this.prEncodeBuffer(buffer));}
+	}
 
 	kNearest{ |buffer, k, action|
-        actions[\kNearest] = [strings(FluidMessageResponse,_,_),action];
+		actions[\kNearest] = [strings(FluidMessageResponse,_,_),action];
 		this.prSendMsg(this.kNearestMsg(buffer,k));
 	}
 
-    kNearestDistMsg {|buffer|
-        ^this.prMakeMsg(\kNearestDist,id,this.prEncodeBuffer(buffer));
-    }
+	kNearestDistMsg {|buffer|
+		^this.prMakeMsg(\kNearestDist,id,this.prEncodeBuffer(buffer));
+	}
 
 	kNearestDist { |buffer, action|
-        actions[\kNearestDist] = [numbers(FluidMessageResponse,_,nil,_),action];
+		actions[\kNearestDist] = [numbers(FluidMessageResponse,_,nil,_),action];
 		this.prSendMsg(this.kNearestDistMsg(buffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer, numNeighbours = 1, lookupDataSet|
-/*        this.numNeighbours_(numNeighbours);
-        lookupDataSet = lookupDataSet ? -1;
-        this.lookupDataSet_(lookupDataSet);*/
+	kr{|trig, inputBuffer,outputBuffer, numNeighbours = 1, lookupDataSet|
+		/*        this.numNeighbours_(numNeighbours);
+		lookupDataSet = lookupDataSet ? -1;
+		this.lookupDataSet_(lookupDataSet);*/
 
-        ^FluidKDTreeQuery.kr(trig,
-            this, numNeighbours, this.radius,lookupDataSet.asUGenInput,
-            inputBuffer,outputBuffer);
-    }
+		^FluidKDTreeQuery.kr(trig,
+			this, numNeighbours, this.radius,lookupDataSet.asUGenInput,
+			inputBuffer,outputBuffer);
+	}
 
 }
 
 FluidKDTreeQuery : FluidRTMultiOutUGen
 {
-    *kr{ |trig, tree, numNeighbours, radius,lookupDataSet, inputBuffer, outputBuffer |
-        ^this.multiNew('control',trig, tree.asUGenInput, numNeighbours, radius,lookupDataSet!?(_.asUGenInput)??{-1}, inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, tree, numNeighbours, radius,lookupDataSet, inputBuffer, outputBuffer |
+		^this.multiNew('control',trig, tree.asUGenInput, numNeighbours, radius,lookupDataSet!?(_.asUGenInput)??{-1}, inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidKMeans.sc
+++ b/release-packaging/Classes/FluidKMeans.sc
@@ -80,9 +80,9 @@ FluidKMeans : FluidModelObject {
 	transformPointMsg{ |sourceBuffer, targetBuffer|
 		^this.prMakeMsg(\transformPoint, id,
 			this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(targetBuffer),
-            ["/b_query", targetBuffer.asUGenInput]);
-    }
+			this.prEncodeBuffer(targetBuffer),
+			["/b_query", targetBuffer.asUGenInput]);
+	}
 
 	transformPoint { |sourceBuffer, targetBuffer, action|
 		actions[\transformPoint] = [nil,{action.value(targetBuffer)}];
@@ -91,40 +91,40 @@ FluidKMeans : FluidModelObject {
 
 	getMeansMsg{|dataSet| ^this.prMakeMsg(\getMeans, id, dataSet.asUGenInput) }
 
-    getMeans{ |dataSet, action|
-        actions[\getMeans] = [nil, action];
+	getMeans{ |dataSet, action|
+		actions[\getMeans] = [nil, action];
 		this.prSendMsg(this.getMeansMsg(dataSet));
 	}
 
 	setMeansMsg{|dataSet| ^this.prMakeMsg(\setMeans, id, dataSet.asUGenInput) }
 
-    setMeans{ |dataSet, action|
-        actions[\setMeans] = [nil, action];
+	setMeans{ |dataSet, action|
+		actions[\setMeans] = [nil, action];
 		this.prSendMsg(this.setMeansMsg(dataSet));
 	}
 
 	clearMsg{ ^this.prMakeMsg(\clear, id) }
 
-    clear{ |action|
-        actions[\clear] = [nil, action];
+	clear{ |action|
+		actions[\clear] = [nil, action];
 		this.prSendMsg(this.clearMsg);
 	}
 
 	kr{|trig, inputBuffer,outputBuffer|
-        ^FluidKMeansQuery.kr(trig,
-            this,
-            this.prEncodeBuffer(inputBuffer),
-            this.prEncodeBuffer(outputBuffer));
+		^FluidKMeansQuery.kr(trig,
+			this,
+			this.prEncodeBuffer(inputBuffer),
+			this.prEncodeBuffer(outputBuffer));
 	}
 }
 
 FluidKMeansQuery : FluidRTMultiOutUGen {
 
-    *kr{ |trig, model,inputBuffer, outputBuffer |
-        ^this.multiNew('control',trig, model.asUGenInput,inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model,inputBuffer, outputBuffer |
+		^this.multiNew('control',trig, model.asUGenInput,inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidKNNClassifier.sc
+++ b/release-packaging/Classes/FluidKNNClassifier.sc
@@ -1,60 +1,60 @@
 FluidKNNClassifier : FluidModelObject {
 
-    var <>numNeighbours, <>weight;
+	var <>numNeighbours, <>weight;
 
 	*new {|server, numNeighbours = 3, weight = 1|
 		^super.new(server,[numNeighbours,weight])
-        .numNeighbours_(numNeighbours)
-        .weight_(weight);
+		.numNeighbours_(numNeighbours)
+		.weight_(weight);
 	}
 
-    prGetParams{^[this.id,this.numNeighbours,this.weight];}
+	prGetParams{^[this.id,this.numNeighbours,this.weight];}
 
-    fitMsg{|dataSet, labelSet|
-        ^this.prMakeMsg(\fit, id, dataSet.id, labelSet.id)
-    }
+	fitMsg{|dataSet, labelSet|
+		^this.prMakeMsg(\fit, id, dataSet.id, labelSet.id)
+	}
 
 	fit{|dataSet, labelSet, action|
-        actions[\fit] = [nil,action];
-	    this.prSendMsg(this.fitMsg(dataSet, labelSet));
+		actions[\fit] = [nil,action];
+		this.prSendMsg(this.fitMsg(dataSet, labelSet));
 	}
 
-    predictMsg{|dataSet, labelSet|
-        ^this.prMakeMsg(\predict, id, dataSet.id, labelSet.id)
-    }
+	predictMsg{|dataSet, labelSet|
+		^this.prMakeMsg(\predict, id, dataSet.id, labelSet.id)
+	}
 
-    predict{|dataSet, labelSet, action|
-        actions[\predict] = [nil, action];
+	predict{|dataSet, labelSet, action|
+		actions[\predict] = [nil, action];
 		this.prSendMsg(this.predictMsg(dataSet, labelSet));
 	}
 
-    predictPointMsg{|buffer|
-        ^this.prMakeMsg(\predictPoint, id, this.prEncodeBuffer(buffer))
-    }
+	predictPointMsg{|buffer|
+		^this.prMakeMsg(\predictPoint, id, this.prEncodeBuffer(buffer))
+	}
 
 	predictPoint {|buffer, action|
 		actions[\predictPoint] = [string(FluidMessageResponse,_,_),action];
 		this.prSendMsg(this.predictPointMsg(buffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer|
-        ^FluidKNNClassifierQuery.kr(trig,
-                this, this.numNeighbours, this.weight,
-                this.prEncodeBuffer(inputBuffer),
-                this.prEncodeBuffer(outputBuffer));
-    }
+	kr{|trig, inputBuffer,outputBuffer|
+		^FluidKNNClassifierQuery.kr(trig,
+			this, this.numNeighbours, this.weight,
+			this.prEncodeBuffer(inputBuffer),
+			this.prEncodeBuffer(outputBuffer));
+	}
 
 }
 
 FluidKNNClassifierQuery : FluidRTMultiOutUGen {
 
-    *kr{ |trig, model,numNeighbours = 3, weight = 1,inputBuffer, outputBuffer |
-        ^this.multiNew('control',trig, model.asUGenInput,
-            numNeighbours,weight,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model,numNeighbours = 3, weight = 1,inputBuffer, outputBuffer |
+		^this.multiNew('control',trig, model.asUGenInput,
+			numNeighbours,weight,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidKNNRegressor.sc
+++ b/release-packaging/Classes/FluidKNNRegressor.sc
@@ -1,59 +1,59 @@
 FluidKNNRegressor : FluidModelObject {
 
-    var <>numNeighbours, <>weight;
+	var <>numNeighbours, <>weight;
 
 	*new {|server, numNeighbours = 3, weight = 1|
 		^super.new(server,[numNeighbours,weight])
-        .numNeighbours_(numNeighbours)
-        .weight_(weight);
+		.numNeighbours_(numNeighbours)
+		.weight_(weight);
 	}
 
-    prGetParams{^[this.id,this.numNeighbours,this.weight,-1,-1];}
+	prGetParams{^[this.id,this.numNeighbours,this.weight,-1,-1];}
 
-    fitMsg{|sourceDataSet, targetDataSet|
-        ^this.prMakeMsg(\fit,this.id,sourceDataSet.id,targetDataSet.id)
-    }
+	fitMsg{|sourceDataSet, targetDataSet|
+		^this.prMakeMsg(\fit,this.id,sourceDataSet.id,targetDataSet.id)
+	}
 
 	fit{|sourceDataSet, targetDataSet, action|
-        actions[\fit] = [nil,action];
-	    this.prSendMsg(this.fitMsg(sourceDataSet, targetDataSet));
+		actions[\fit] = [nil,action];
+		this.prSendMsg(this.fitMsg(sourceDataSet, targetDataSet));
 	}
 
-    predictMsg{ |sourceDataSet, targetDataSet|
-        ^this.prMakeMsg(\predict,this.id,sourceDataSet.id,targetDataSet.id)
-    }
+	predictMsg{ |sourceDataSet, targetDataSet|
+		^this.prMakeMsg(\predict,this.id,sourceDataSet.id,targetDataSet.id)
+	}
 
 	predict{ |sourceDataSet, targetDataSet,action|
-        actions[\predict] = [nil, action];
+		actions[\predict] = [nil, action];
 		this.prSendMsg(this.predictMsg(sourceDataSet, targetDataSet));
 	}
 
-    predictPointMsg { |buffer|
-        ^this.prMakeMsg(\predictPoint,id, this.prEncodeBuffer(buffer));
-    }
+	predictPointMsg { |buffer|
+		^this.prMakeMsg(\predictPoint,id, this.prEncodeBuffer(buffer));
+	}
 
 	predictPoint { |buffer, action|
 		actions[\predictPoint] = [number(FluidMessageResponse,_,_),action];
 		this.prSendMsg(this.predictPointMsg(buffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer|
-        ^FluidKNNRegressorQuery.kr(K2A.ar(trig),
-                this, this.numNeighbours, this.weight,
-                this.prEncodeBuffer(inputBuffer),
-                this.prEncodeBuffer(outputBuffer));
-    }
+	kr{|trig, inputBuffer,outputBuffer|
+		^FluidKNNRegressorQuery.kr(K2A.ar(trig),
+			this, this.numNeighbours, this.weight,
+			this.prEncodeBuffer(inputBuffer),
+			this.prEncodeBuffer(outputBuffer));
+	}
 }
 
 FluidKNNRegressorQuery : FluidRTMultiOutUGen {
 
-    *kr{ |trig, model,numNeighbours = 3, weight = 1,inputBuffer, outputBuffer |
-        ^this.multiNew('control',trig, model.asUGenInput,
-            numNeighbours,weight,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model,numNeighbours = 3, weight = 1,inputBuffer, outputBuffer |
+		^this.multiNew('control',trig, model.asUGenInput,
+			numNeighbours,weight,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidLabelSet.sc
+++ b/release-packaging/Classes/FluidLabelSet.sc
@@ -1,19 +1,19 @@
 FluidLabelSet : FluidDataObject {
 
-    *new{|server| ^super.new(server) }
+	*new{|server| ^super.new(server) }
 
-    addLabelMsg{|identifier,label|
-        ^this.prMakeMsg(\addLabel,id,identifier.asSymbol,label.asSymbol);
-    }
+	addLabelMsg{|identifier,label|
+		^this.prMakeMsg(\addLabel,id,identifier.asSymbol,label.asSymbol);
+	}
 
 	addLabel{|identifier, label, action|
-        actions[\addLabel] = [nil, action];
+		actions[\addLabel] = [nil, action];
 		this.prSendMsg(this.addLabelMsg(identifier,label));
 	}
 
-    updateLabelMsg{|identifier, label|
-        ^this.prMakeMsg(\updateLabel, id, identifier.asSymbol, label.asSymbol);
-    }
+	updateLabelMsg{|identifier, label|
+		^this.prMakeMsg(\updateLabel, id, identifier.asSymbol, label.asSymbol);
+	}
 
 	setLabelMsg{|identifier,label|
 		^this.prMakeMsg(\setLabel,id,identifier.asSymbol,label.asSymbol);
@@ -25,36 +25,36 @@ FluidLabelSet : FluidDataObject {
 	}
 
 	updateLabel{|identifier, label, action|
-        actions[\updateLabel] = [nil,action];
+		actions[\updateLabel] = [nil,action];
 		this.prSendMsg(this.updateLabelMsg(identifier,label));
 	}
 
-    getLabelMsg{|identifier|
-        ^this.prMakeMsg(\getLabel, id, identifier.asSymbol);
-    }
+	getLabelMsg{|identifier|
+		^this.prMakeMsg(\getLabel, id, identifier.asSymbol);
+	}
 
 	getLabel{|identifier, action|
-        actions[\getLabel] = [string(FluidMessageResponse,_,_),action];
+		actions[\getLabel] = [string(FluidMessageResponse,_,_),action];
 		this.prSendMsg(this.getLabelMsg(identifier));
 	}
 
-    deleteLabelMsg{|identifier, action|
-    	^this.prMakeMsg(\deleteLabel, id, identifier.asSymbol);
-    }
+	deleteLabelMsg{|identifier, action|
+		^this.prMakeMsg(\deleteLabel, id, identifier.asSymbol);
+	}
 
 	deleteLabel{|identifier, action|
-        actions[\deleteLabel] = [nil, action];
+		actions[\deleteLabel] = [nil, action];
 		this.prSendMsg(this.deleteLabelMsg(identifier));
 	}
 
-    clearMsg { ^this.prMakeMsg(\clear,id); }
+	clearMsg { ^this.prMakeMsg(\clear,id); }
 
-    clear { |action|
-      actions[\clear] = [nil,action];
-      this.prSendMsg(this.clearMsg);
-    }
+	clear { |action|
+		actions[\clear] = [nil,action];
+		this.prSendMsg(this.clearMsg);
+	}
 
-    printMsg { ^this.prMakeMsg(\print,id); }
+	printMsg { ^this.prMakeMsg(\print,id); }
 
 	print { |action=(postResponse)|
 		actions[\print] = [string(FluidMessageResponse,_,_),action];
@@ -62,11 +62,11 @@ FluidLabelSet : FluidDataObject {
 	}
 
 	getIdsMsg{|labelSet|
-        ^this.prMakeMsg(\getIds, id, labelSet.asUGenInput);
-    }
+		^this.prMakeMsg(\getIds, id, labelSet.asUGenInput);
+	}
 
 	getIds{|labelSet, action|
-      actions[\getIds] = [nil,action];
-	  this.prSendMsg(this.getIdsMsg(labelSet));
+		actions[\getIds] = [nil,action];
+		this.prSendMsg(this.getIdsMsg(labelSet));
 	}
 }

--- a/release-packaging/Classes/FluidLoudness.sc
+++ b/release-packaging/Classes/FluidLoudness.sc
@@ -1,43 +1,43 @@
 FluidLoudness : FluidRTMultiOutUGen {
 
-    const <features=#[\loudness, \peak];
-    classvar featuresLookup;
+	const <features=#[\loudness, \peak];
+	classvar featuresLookup;
 
-    *initClass {
-        featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
-    }
+	*initClass {
+		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
+	}
 
-    *prWarnUnrecognised {|sym| ("WARNING: FluidLoudness -" + sym + "is not a recognised option").postln}
+	*prWarnUnrecognised {|sym| ("WARNING: FluidLoudness -" + sym + "is not a recognised option").postln}
 
-    *prProcessSelect {|a|
-        var bits;
-        a.asBag.countsDo{|item,count,i|
-            if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-        };
-        bits = a.collect{ |sym|
-            (featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-        }.reduce{|x,y| x | y};
-        ^bits
-    }
+	*prProcessSelect {|a|
+		var bits;
+		a.asBag.countsDo{|item,count,i|
+			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
+		};
+		bits = a.collect{ |sym|
+			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
+		}.reduce{|x,y| x | y};
+		^bits
+	}
 
 	*kr { arg in = 0, select, kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, maxWindowSize = 16384;
 
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
 
 		^this.multiNew('control', in.asAudioRateInput(this), selectbits, kWeighting, truePeak, windowSize, hopSize, maxWindowSize);
 	}
 
-    init {arg ...theInputs;
-        var numChannels;
+	init {arg ...theInputs;
+		var numChannels;
 		inputs = theInputs;
-        numChannels = inputs.at(1).asBinaryDigits.sum;
+		numChannels = inputs.at(1).asBinaryDigits.sum;
 		^this.initOutputs(numChannels,rate);
 	}
 
 	checkInputs {
 		if(inputs.at(6).rate != 'scalar') {
 			^(": maxwindowSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidMDS.sc
+++ b/release-packaging/Classes/FluidMDS.sc
@@ -7,25 +7,25 @@ FluidMDS : FluidModelObject {
 	classvar < kl = 5;
 	classvar < cosine = 5;
 
-    var <>numDimensions, <>distanceMetric;
+	var <>numDimensions, <>distanceMetric;
 
 	*new {|server,numDimensions = 2, distanceMetric = 1|
 		^super.new(server,[numDimensions, distanceMetric])
-        .numDimensions_(numDimensions)
-        .distanceMetric_(distanceMetric);
+		.numDimensions_(numDimensions)
+		.distanceMetric_(distanceMetric);
 	}
 
-    prGetParams{
-        ^[this.numDimensions, this.distanceMetric];
-    }
+	prGetParams{
+		^[this.numDimensions, this.distanceMetric];
+	}
 
 	fitTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\fitTransform,id, sourceDataSet.id,  destDataSet.id);
-    }
+		^this.prMakeMsg(\fitTransform,id, sourceDataSet.id,  destDataSet.id);
+	}
 
 	fitTransform{|sourceDataSet, destDataSet, action|
-        actions[\fitTransform] = [nil,action];
-        this.fitTransformMsg(sourceDataSet,destDataSet);
+		actions[\fitTransform] = [nil,action];
+		this.fitTransformMsg(sourceDataSet,destDataSet);
 
 		this.prSendMsg(this.fitTransformMsg(sourceDataSet,destDataSet));
 	}

--- a/release-packaging/Classes/FluidMFCC.sc
+++ b/release-packaging/Classes/FluidMFCC.sc
@@ -2,8 +2,8 @@ FluidMFCC : FluidRTMultiOutUGen {
 
 	*kr { arg in = 0, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1, maxNumCoeffs = nil, maxNumBands = nil;
 
-        maxNumCoeffs = maxNumCoeffs ? numCoeffs;
-        maxNumBands =  maxNumBands ? numBands;
+		maxNumCoeffs = maxNumCoeffs ? numCoeffs;
+		maxNumBands =  maxNumBands ? numBands;
 
 		^this.multiNew('control', in.asAudioRateInput(this), numCoeffs, maxNumCoeffs, numBands, maxNumBands, startCoeff, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize);
 	}
@@ -19,7 +19,7 @@ FluidMFCC : FluidRTMultiOutUGen {
 		if(inputs.at(2).rate != 'scalar') {
 			^(": maxNumCoeffs cannot be modulated.");
 		};
-        if(inputs.at(4).rate != 'scalar') {
+		if(inputs.at(4).rate != 'scalar') {
 			^(": maxNumBands cannot be modulated.");
 		};
 		if(inputs.at(10).rate != 'scalar') {

--- a/release-packaging/Classes/FluidMLP.sc
+++ b/release-packaging/Classes/FluidMLP.sc
@@ -5,109 +5,109 @@ FluidMLPRegressor : FluidModelObject {
 	const <relu = 2;
 	const <tanh = 3;
 
-    var <>hiddenLayers, <>activation, <>outputActivation, <>tapIn, <>tapOut, <>maxIter, <>learnRate, <>momentum, <>batchSize, <>validation;
+	var <>hiddenLayers, <>activation, <>outputActivation, <>tapIn, <>tapOut, <>maxIter, <>learnRate, <>momentum, <>batchSize, <>validation;
 
 	*new {|server, hiddenLayers = #[3,3] , activation = 2, outputActivation = 0, tapIn = 0, tapOut = -1,maxIter = 1000, learnRate = 0.0001, momentum = 0.9, batchSize = 50, validation = 0.2|
 
 		^super.new(server, [hiddenLayers.size] ++ hiddenLayers ++ [activation, outputActivation, tapIn, tapOut, maxIter, learnRate, momentum, batchSize, validation])
-            .hiddenLayers_(hiddenLayers)
-            .activation_(activation)
-            .outputActivation_(outputActivation)
-            .tapIn_(tapIn)
-            .tapOut_(tapOut)
-            .maxIter_(maxIter)
-            .learnRate_(learnRate)
-            .momentum_(momentum)
-            .batchSize_(batchSize)
-            .validation_(validation);
+		.hiddenLayers_(hiddenLayers)
+		.activation_(activation)
+		.outputActivation_(outputActivation)
+		.tapIn_(tapIn)
+		.tapOut_(tapOut)
+		.maxIter_(maxIter)
+		.learnRate_(learnRate)
+		.momentum_(momentum)
+		.batchSize_(batchSize)
+		.validation_(validation);
 	}
 
-    prGetParams{
-        ^[this.id, this.hiddenLayers.size] ++ this.hiddenLayers ++ [this.activation, this.outputActivation, this.tapIn, this.tapOut, this.maxIter, this.learnRate, this.momentum, this.batchSize, this.validation]
-    }
+	prGetParams{
+		^[this.id, this.hiddenLayers.size] ++ this.hiddenLayers ++ [this.activation, this.outputActivation, this.tapIn, this.tapOut, this.maxIter, this.learnRate, this.momentum, this.batchSize, this.validation]
+	}
 
-    clearMsg{ ^this.prMakeMsg(\clear, id) }
+	clearMsg{ ^this.prMakeMsg(\clear, id) }
 
-    clear{ |action|
-        actions[\clear] = [nil, action];
+	clear{ |action|
+		actions[\clear] = [nil, action];
 		this.prSendMsg(this.clearMsg);
 	}
 
-    fitMsg{|sourceDataSet, targetDataSet|
-        ^this.prMakeMsg(\fit,id,sourceDataSet.id, targetDataSet.id);
-    }
-
-	fit{|sourceDataSet, targetDataSet, action|
-	   actions[\fit] = [numbers(FluidMessageResponse,_,1,_),action];
-       this.prSendMsg(this.fitMsg(sourceDataSet,targetDataSet));
+	fitMsg{|sourceDataSet, targetDataSet|
+		^this.prMakeMsg(\fit,id,sourceDataSet.id, targetDataSet.id);
 	}
 
-    predictMsg{|sourceDataSet, targetDataSet|
-        ^this.prMakeMsg(\predict,id,sourceDataSet.id, targetDataSet.id);
-    }
+	fit{|sourceDataSet, targetDataSet, action|
+		actions[\fit] = [numbers(FluidMessageResponse,_,1,_),action];
+		this.prSendMsg(this.fitMsg(sourceDataSet,targetDataSet));
+	}
+
+	predictMsg{|sourceDataSet, targetDataSet|
+		^this.prMakeMsg(\predict,id,sourceDataSet.id, targetDataSet.id);
+	}
 
 	predict{|sourceDataSet, targetDataSet, action|
-	   actions[\predict] = [nil,action];
-       this.prSendMsg(this.predictMsg(sourceDataSet,targetDataSet));
+		actions[\predict] = [nil,action];
+		this.prSendMsg(this.predictMsg(sourceDataSet,targetDataSet));
 	}
 
 
 	predictPointMsg { |sourceBuffer, targetBuffer|
-        ^this.prMakeMsg(\predictPoint,id,
-            this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(targetBuffer),
-            ["/b_query", targetBuffer.asUGenInput]);
-    }
+		^this.prMakeMsg(\predictPoint,id,
+			this.prEncodeBuffer(sourceBuffer),
+			this.prEncodeBuffer(targetBuffer),
+			["/b_query", targetBuffer.asUGenInput]);
+	}
 
 	predictPoint { |sourceBuffer, targetBuffer, action|
-        actions[\predictPoint] = [nil,{action.value(targetBuffer)}];
-        this.predictPointMsg(sourceBuffer, targetBuffer);
+		actions[\predictPoint] = [nil,{action.value(targetBuffer)}];
+		this.predictPointMsg(sourceBuffer, targetBuffer);
 		this.prSendMsg(this.predictPointMsg(sourceBuffer, targetBuffer));
 	}
 
-    read { |filename, action|
-        actions[\read] = [numbers(FluidMessageResponse,_,nil,_), {
-            |data|
-            this.prUpdateParams(data);
-            action.value;
-        }];
-      this.prSendMsg(this.readMsg(filename));
-    }
+	read { |filename, action|
+		actions[\read] = [numbers(FluidMessageResponse,_,nil,_), {
+			|data|
+			this.prUpdateParams(data);
+			action.value;
+		}];
+		this.prSendMsg(this.readMsg(filename));
+	}
 
-    kr{|trig, inputBuffer,outputBuffer, tapIn = 0, tapOut = -1|
-        var params;
-        tapIn = tapIn ? this.tapIn;
-        tapOut = tapOut ? this.tapOut;
+	kr{|trig, inputBuffer,outputBuffer, tapIn = 0, tapOut = -1|
+		var params;
+		tapIn = tapIn ? this.tapIn;
+		tapOut = tapOut ? this.tapOut;
 
-        this.tapIn_(tapIn).tapOut_(tapOut);
+		this.tapIn_(tapIn).tapOut_(tapOut);
 
-        params = [this.prEncodeBuffer(inputBuffer),
-        this.prEncodeBuffer(outputBuffer),this.tapIn,this.tapOut];
+		params = [this.prEncodeBuffer(inputBuffer),
+			this.prEncodeBuffer(outputBuffer),this.tapIn,this.tapOut];
 
-        ^FluidMLPRegressorQuery.kr(trig,this, *params);
-    }
+		^FluidMLPRegressorQuery.kr(trig,this, *params);
+	}
 
-    prUpdateParams{|data|
-        var rest = data.keep(-9);
-        this.hiddenLayers_(data.drop(1).drop(-9).copy);
-        [\activation_, \outputActivation_,
-            \tapIn_, \tapOut_, \maxIter_,
-            \learnRate_, \momentum_,
-            \batchSize_, \validation_]
-        .do{|prop,i|
-            this.performList(prop,rest[i]);
-        };
-    }
+	prUpdateParams{|data|
+		var rest = data.keep(-9);
+		this.hiddenLayers_(data.drop(1).drop(-9).copy);
+		[\activation_, \outputActivation_,
+			\tapIn_, \tapOut_, \maxIter_,
+			\learnRate_, \momentum_,
+			\batchSize_, \validation_]
+		.do{|prop,i|
+			this.performList(prop,rest[i]);
+		};
+	}
 }
 
 FluidMLPRegressorQuery : FluidRTMultiOutUGen {
-    *kr{ |trig, model, inputBuffer,outputBuffer, tapIn = 0, tapOut = -1|
-        ^this.multiNew('control',trig, model.asUGenInput,
-            tapIn, tapOut,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model, inputBuffer,outputBuffer, tapIn = 0, tapOut = -1|
+		^this.multiNew('control',trig, model.asUGenInput,
+			tapIn, tapOut,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}
@@ -120,94 +120,94 @@ FluidMLPClassifier : FluidModelObject {
 	const <relu = 2;
 	const <tanh = 3;
 
-    var <>hiddenLayers, <>activation, <> maxIter, <>learnRate, <> momentum, <>batchSize, <>validation;
+	var <>hiddenLayers, <>activation, <> maxIter, <>learnRate, <> momentum, <>batchSize, <>validation;
 
 	*new {|server, hiddenLayers = #[3,3] , activation = 2, maxIter = 1000, learnRate = 0.0001, momentum = 0.9, batchSize = 50, validation = 0.2|
 		^super.new(server,[hiddenLayers.size] ++ hiddenLayers ++ [activation,  maxIter, learnRate,  momentum, batchSize, validation])
-        .hiddenLayers_(hiddenLayers)
-			.activation_(activation)
-			.maxIter_(maxIter)
-			.learnRate_(learnRate)
-			.momentum_(momentum)
-			.batchSize_(batchSize)
-			.validation_(validation);
+		.hiddenLayers_(hiddenLayers)
+		.activation_(activation)
+		.maxIter_(maxIter)
+		.learnRate_(learnRate)
+		.momentum_(momentum)
+		.batchSize_(batchSize)
+		.validation_(validation);
 	}
 
-    prGetParams{
-        ^[this.id, this.hiddenLayers.size] ++ this.hiddenLayers ++ [this.activation,  this.maxIter, this.learnRate,  this.momentum, this.batchSize, this.validation];
-    }
+	prGetParams{
+		^[this.id, this.hiddenLayers.size] ++ this.hiddenLayers ++ [this.activation,  this.maxIter, this.learnRate,  this.momentum, this.batchSize, this.validation];
+	}
 
-    clearMsg{ ^this.prMakeMsg(\clear,id) }
+	clearMsg{ ^this.prMakeMsg(\clear,id) }
 
 	clear{ |action|
-        actions[\clear] = [nil,action];
+		actions[\clear] = [nil,action];
 		this.prSendMsg(this.clearMsg);
 	}
 
-    fitMsg{|sourceDataSet, targetLabelSet|
-        ^this.prMakeMsg(\fit,id,sourceDataSet.id, targetLabelSet.id);
-    }
-
-	fit{|sourceDataSet, targetLabelSet, action|
-       actions[\fit] = [numbers(FluidMessageResponse,_,1,_),action];
-	   this.prSendMsg(this.fitMsg(sourceDataSet,targetLabelSet));
+	fitMsg{|sourceDataSet, targetLabelSet|
+		^this.prMakeMsg(\fit,id,sourceDataSet.id, targetLabelSet.id);
 	}
 
-    predictMsg{|sourceDataSet, targetLabelSet|
-        ^this.prMakeMsg(\predict,id,sourceDataSet.id, targetLabelSet.id);
-    }
+	fit{|sourceDataSet, targetLabelSet, action|
+		actions[\fit] = [numbers(FluidMessageResponse,_,1,_),action];
+		this.prSendMsg(this.fitMsg(sourceDataSet,targetLabelSet));
+	}
+
+	predictMsg{|sourceDataSet, targetLabelSet|
+		^this.prMakeMsg(\predict,id,sourceDataSet.id, targetLabelSet.id);
+	}
 
 	predict{ |sourceDataSet, targetLabelSet, action|
-        actions[\predict]=[nil,action];
+		actions[\predict]=[nil,action];
 		this.prSendMsg(this.predictMsg(sourceDataSet,targetLabelSet));
 	}
 
-    predictPointMsg { |sourceBuffer|
-        ^this.prMakeMsg(\predictPoint,id,this.prEncodeBuffer(sourceBuffer))
-    }
+	predictPointMsg { |sourceBuffer|
+		^this.prMakeMsg(\predictPoint,id,this.prEncodeBuffer(sourceBuffer))
+	}
 
 	predictPoint { |sourceBuffer, action|
-        actions[\predictPoint] = [string(FluidMessageResponse,_,_),action];
+		actions[\predictPoint] = [string(FluidMessageResponse,_,_),action];
 		this.prSendMsg(this.predictPointMsg(sourceBuffer));
 	}
 
 
-    read { |filename, action|
-        actions[\read] = [numbers(FluidMessageResponse,_,nil,_), {
-            |data|
-            this.prUpdateParams(data);
-            action.value;
-        }];
-      this.prSendMsg(this.readMsg(filename));
-    }
+	read { |filename, action|
+		actions[\read] = [numbers(FluidMessageResponse,_,nil,_), {
+			|data|
+			this.prUpdateParams(data);
+			action.value;
+		}];
+		this.prSendMsg(this.readMsg(filename));
+	}
 
-    prUpdateParams{|data|
-        var rest = data.keep(-6);
-        this.hiddenLayers_(data.drop(1).drop(-6).copy);
-        [\activation_, \maxIter_,
-            \learnRate_, \momentum_,
-            \batchSize_, \validation_]
-        .do{|prop,i|
-            this.performList(prop,rest[i]);
-        };
-    }
+	prUpdateParams{|data|
+		var rest = data.keep(-6);
+		this.hiddenLayers_(data.drop(1).drop(-6).copy);
+		[\activation_, \maxIter_,
+			\learnRate_, \momentum_,
+			\batchSize_, \validation_]
+		.do{|prop,i|
+			this.performList(prop,rest[i]);
+		};
+	}
 
-    kr{|trig, inputBuffer,outputBuffer|
+	kr{|trig, inputBuffer,outputBuffer|
 
-        var params = [this.prEncodeBuffer(inputBuffer),
-        this.prEncodeBuffer(outputBuffer)];
+		var params = [this.prEncodeBuffer(inputBuffer),
+			this.prEncodeBuffer(outputBuffer)];
 
-        ^FluidMLPClassifierQuery.kr(trig,this, *params);
-    }
+		^FluidMLPClassifierQuery.kr(trig,this, *params);
+	}
 }
 
 FluidMLPClassifierQuery : FluidRTMultiOutUGen {
-    *kr{ |trig, model, inputBuffer,outputBuffer|
-        ^this.multiNew('control',trig, model.asUGenInput,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model, inputBuffer,outputBuffer|
+		^this.multiNew('control',trig, model.asUGenInput,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidManipulationJSON.sc
+++ b/release-packaging/Classes/FluidManipulationJSON.sc
@@ -8,17 +8,17 @@
 		var filename = this.tmpJSONFilename;
 		action ?? {action = postResponse};
 		this.write(filename, {
-				action.value(this.parseJSON(File.readAllString(filename)));
-				File.delete(filename);
-			});
+			action.value(this.parseJSON(File.readAllString(filename)));
+			File.delete(filename);
+		});
 	}
 
 	load{|dict, action|
 		var filename = this.tmpJSONFilename;
 		File.use(filename, "wt", { |f| f.write(this.asJSON(dict));});
 		this.read(filename, {
-				action.notNil.if{ action.value; };
-				File.delete(filename);
+			action.notNil.if{ action.value; };
+			File.delete(filename);
 		});
 	}
 
@@ -55,9 +55,9 @@
 		if(d.isKindOf(Symbol)){^this.asJSON(d.asString)};
 		if(d.isKindOf(Dictionary))
 		{
-		  ^"{" ++ (
-			d.keys.asList.collect{|k|
-			k.asString.asCompileString ++ ":" + this.asJSON(d[k])
+			^"{" ++ (
+				d.keys.asList.collect{|k|
+					k.asString.asCompileString ++ ":" + this.asJSON(d[k])
 			}).join(", ") ++ "}"
 		};
 		if(d.isKindOf(SequenceableCollection))

--- a/release-packaging/Classes/FluidMelBands.sc
+++ b/release-packaging/Classes/FluidMelBands.sc
@@ -1,9 +1,9 @@
 FluidMelBands : FluidRTMultiOutUGen {
 
 	*kr { arg in = 0, numBands = 40, minFreq = 20, maxFreq = 20000, normalize = 1, scale = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1, maxNumBands;
-        
-        maxNumBands = maxNumBands ? numBands; 
-        
+
+		maxNumBands = maxNumBands ? numBands;
+
 		^this.multiNew('control', in.asAudioRateInput(this), numBands, maxNumBands, minFreq, maxFreq, normalize, scale, windowSize, hopSize, fftSize, maxFFTSize);
 	}
 

--- a/release-packaging/Classes/FluidMessageResponse.sc
+++ b/release-packaging/Classes/FluidMessageResponse.sc
@@ -1,41 +1,41 @@
 FluidMessageResponse : Object
 {
-    //selectors is an array of functions
-    //my cunning thought is that those that need extra data (e..g numbers()) can
-    //use partial applicaiton
-    *collectArgs{ |selectors,a|
-        var response = [];
-        var idx = 0;
-        selectors.do{ |selector|
-            var newThings;
-            # newThings,idx = selector.value(a, idx);
-            response = response ++ newThings;
-        };
+	//selectors is an array of functions
+	//my cunning thought is that those that need extra data (e..g numbers()) can
+	//use partial applicaiton
+	*collectArgs{ |selectors,a|
+		var response = [];
+		var idx = 0;
+		selectors.do{ |selector|
+			var newThings;
+			# newThings,idx = selector.value(a, idx);
+			response = response ++ newThings;
+		};
 
-        if(response.size == 1,
-            {^response[0]},{^response})
-    }
+		if(response.size == 1,
+			{^response[0]},{^response})
+	}
 
-    *string{ |a, offset|
-        ^[a]
-    }
+	*string{ |a, offset|
+		^[a]
+	}
 
-    *strings {|a,offset|
-        //TODO add an n argument as with numbers() to make this less omnivorous
-        ^[a.drop(offset)];
-    }
+	*strings {|a,offset|
+		//TODO add an n argument as with numbers() to make this less omnivorous
+		^[a.drop(offset)];
+	}
 
-    *numbers{ |a, n, offset|
-        n = n ? a.size - offset; //send n = nil to consume everything
-        ^[a.copyRange(offset, offset + n),offset + n]
-    }
+	*numbers{ |a, n, offset|
+		n = n ? a.size - offset; //send n = nil to consume everything
+		^[a.copyRange(offset, offset + n),offset + n]
+	}
 
-    *number{ |a,offset|
-        ^[a[offset]];
-    }
+	*number{ |a,offset|
+		^[a[offset]];
+	}
 
-    *buffer{ |a,server,offset|
-        server = server ? Server.default ;
-        ^[Buffer.cachedBufferAt(server, a[offset]), offset + 1]
-    }
+	*buffer{ |a,server,offset|
+		server = server ? Server.default ;
+		^[Buffer.cachedBufferAt(server, a[offset]), offset + 1]
+	}
 }

--- a/release-packaging/Classes/FluidNMFFilter.sc
+++ b/release-packaging/Classes/FluidNMFFilter.sc
@@ -10,11 +10,11 @@ FluidNMFFilter : FluidRTMultiOutUGen {
 	}
 
 	checkInputs {
-	if(inputs.at(3).rate != 'scalar') {
-		^(": maxComponents cannot be modulated.");
+		if(inputs.at(3).rate != 'scalar') {
+			^(": maxComponents cannot be modulated.");
 		};
-	if(inputs.at(8).rate != 'scalar') {
-		^(": maxFFTSize cannot be modulated.");
+		if(inputs.at(8).rate != 'scalar') {
+			^(": maxFFTSize cannot be modulated.");
 		};
 		^this.checkValidInputs;
 	}

--- a/release-packaging/Classes/FluidNMFMatch.sc
+++ b/release-packaging/Classes/FluidNMFMatch.sc
@@ -10,11 +10,11 @@ FluidNMFMatch : FluidRTMultiOutUGen {
 	}
 
 	checkInputs {
-	if(inputs.at(3).rate != 'scalar') {
-		^(": maxComponents cannot be modulated.");
+		if(inputs.at(3).rate != 'scalar') {
+			^(": maxComponents cannot be modulated.");
 		};
-	if(inputs.at(8).rate != 'scalar') {
-		^(": maxFFTSize cannot be modulated.");
+		if(inputs.at(8).rate != 'scalar') {
+			^(": maxFFTSize cannot be modulated.");
 		};
 		^this.checkValidInputs;
 	}

--- a/release-packaging/Classes/FluidNRTProcess.sc
+++ b/release-packaging/Classes/FluidNRTProcess.sc
@@ -1,5 +1,5 @@
 FluidNRTProcess : Object{
-    var  <server, <ugen, <action, <outputBuffers, <blocking, <synth;
+	var  <server, <ugen, <action, <outputBuffers, <blocking, <synth;
 
 	*new {|server, ugen, action, outputBuffers, blocking = 0|
 		^super.newCopyArgs(server, ugen, action, outputBuffers, blocking).init;
@@ -8,8 +8,8 @@ FluidNRTProcess : Object{
 	init{
 		server = server ? Server.default;
 		server.ifNotRunning({
-            "FluidNRTProcess: Server not running".throw;
-        });
+			"FluidNRTProcess: Server not running".throw;
+		});
 		if (ugen.isNil){
 			"FluidNRTProcess : FluidRTUGen is nil".throw;
 		};
@@ -24,28 +24,28 @@ FluidNRTProcess : Object{
 
 	process{|...ugenArgs|
 
-        var c = Condition.new(false);
+		var c = Condition.new(false);
 
 		synth = {
-            FreeSelfWhenDone.kr(ugen.performList(\new1,\control, ugenArgs.collect{|a| a.asUGenInput} ++ 1 ++ blocking));
+			FreeSelfWhenDone.kr(ugen.performList(\new1,\control, ugenArgs.collect{|a| a.asUGenInput} ++ 1 ++ blocking));
 		}.play(server);
 		synth.postln;
 
-        OSCFunc({ |m|
-            forkIfNeeded{
-			outputBuffers.do{|buf|
-				buf = server.cachedBufferAt(buf.asUGenInput);
-				buf.updateInfo;
-			};
-            server.sync;
-            if(action.notNil && m[2]==0){action.valueArray(outputBuffers)};
-            c.test = true;
-            c.signal;
-            }
-        },'/done', srcID:server.addr, argTemplate:[synth.nodeID]).oneShot;
+		OSCFunc({ |m|
+			forkIfNeeded{
+				outputBuffers.do{|buf|
+					buf = server.cachedBufferAt(buf.asUGenInput);
+					buf.updateInfo;
+				};
+				server.sync;
+				if(action.notNil && m[2]==0){action.valueArray(outputBuffers)};
+				c.test = true;
+				c.signal;
+			}
+		},'/done', srcID:server.addr, argTemplate:[synth.nodeID]).oneShot;
 
 		forkIfNeeded{
-            c.wait;
+			c.wait;
 		};
 		^this;
 	}

--- a/release-packaging/Classes/FluidNormalize.sc
+++ b/release-packaging/Classes/FluidNormalize.sc
@@ -1,103 +1,103 @@
 FluidNormalize : FluidModelObject {
 
-    var <>min, <>max;
+	var <>min, <>max;
 
 	*new {|server, min = 0, max = 1|
 		^super.new(server,[min,max])
-        .min_(min).max_(max);
+		.min_(min).max_(max);
 	}
 
-    prGetParams{
-        ^[this.id, this.min,this.max,-1,-1];
-    }
+	prGetParams{
+		^[this.id, this.min,this.max,-1,-1];
+	}
 
 
-    fitMsg{|dataSet|
-        ^this.prMakeMsg(\fit,id,dataSet.id)
-    }
+	fitMsg{|dataSet|
+		^this.prMakeMsg(\fit,id,dataSet.id)
+	}
 
 	fit{|dataSet, action|
-        actions[\fit] = [nil,action];
+		actions[\fit] = [nil,action];
 		this.prSendMsg(this.fitMsg(dataSet));
 	}
 
-    transformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\transform,id,sourceDataSet.id,destDataSet.id);
-    }
+	transformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\transform,id,sourceDataSet.id,destDataSet.id);
+	}
 
 	transform{|sourceDataSet, destDataSet, action|
 		actions[\transform] = [nil,action];
-        this.prSendMsg(this.transformMsg(sourceDataSet, destDataSet));
+		this.prSendMsg(this.transformMsg(sourceDataSet, destDataSet));
 	}
 
-    fitTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\fitTransform,id,sourceDataSet.id,destDataSet.id)
-    }
+	fitTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\fitTransform,id,sourceDataSet.id,destDataSet.id)
+	}
 
 	fitTransform{|sourceDataSet, destDataSet, action|
-        actions[\fitTransform] = [nil,action];
+		actions[\fitTransform] = [nil,action];
 		this.prSendMsg(this.fitTransformMsg(sourceDataSet, destDataSet));
 	}
 
-    transformPointMsg{|sourceBuffer, destBuffer|
-        ^this.prMakeMsg(\transformPoint,id,
-            this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(destBuffer),
-            ["/b_query",destBuffer.asUGenInput]
-        );
-    }
-
-	transformPoint{|sourceBuffer, destBuffer, action|
-        actions[\transformPoint] = [nil,{action.value(destBuffer)}];
-        this.prSendMsg(this.transformPointMsg(sourceBuffer, destBuffer));
+	transformPointMsg{|sourceBuffer, destBuffer|
+		^this.prMakeMsg(\transformPoint,id,
+			this.prEncodeBuffer(sourceBuffer),
+			this.prEncodeBuffer(destBuffer),
+			["/b_query",destBuffer.asUGenInput]
+		);
 	}
 
-    inverseTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
-    }
+	transformPoint{|sourceBuffer, destBuffer, action|
+		actions[\transformPoint] = [nil,{action.value(destBuffer)}];
+		this.prSendMsg(this.transformPointMsg(sourceBuffer, destBuffer));
+	}
+
+	inverseTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
+	}
 
 	inverseTransform{|sourceDataSet, destDataSet, action|
 		actions[\inverseTransform] = [nil,action];
-        this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
+		this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
 	}
 
-    inverseTransformPointMsg{|sourceBuffer, destBuffer|
-        ^this.prMakeMsg(\inverseTransformPoint,id,
-            this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(destBuffer),
-            ["/b_query",destBuffer.asUGenInput]
-        );
-    }
+	inverseTransformPointMsg{|sourceBuffer, destBuffer|
+		^this.prMakeMsg(\inverseTransformPoint,id,
+			this.prEncodeBuffer(sourceBuffer),
+			this.prEncodeBuffer(destBuffer),
+			["/b_query",destBuffer.asUGenInput]
+		);
+	}
 
 	inverseTransformPoint{|sourceBuffer, destBuffer, action|
-        actions[\inverseTransformPoint] = [nil,{action.value(destBuffer)}];
-        this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
+		actions[\inverseTransformPoint] = [nil,{action.value(destBuffer)}];
+		this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer,min = 0 ,max = 1,invert = 0|
+	kr{|trig, inputBuffer,outputBuffer,min = 0 ,max = 1,invert = 0|
 
-        min = min ? this.min;
-        max = max ? this.max;
+		min = min ? this.min;
+		max = max ? this.max;
 
-        this.min_(min).max_(max);
+		this.min_(min).max_(max);
 
-        ^FluidNormalizeQuery.kr(trig,
-                this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.min, this.max, invert);
-    }
+		^FluidNormalizeQuery.kr(trig,
+			this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.min, this.max, invert);
+	}
 
 
 }
 
 FluidNormalizeQuery : FluidRTMultiOutUGen {
 
-    *kr{ |trig, model,inputBuffer,outputBuffer,min = 0 ,max = 1,invert = 0|
+	*kr{ |trig, model,inputBuffer,outputBuffer,min = 0 ,max = 1,invert = 0|
 		// inputBuffer.asUGenInput.postln;
-        ^this.multiNew('control',trig, model.asUGenInput,
-            min,max,invert,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+		^this.multiNew('control',trig, model.asUGenInput,
+			min,max,invert,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidNoveltyFeature.sc
+++ b/release-packaging/Classes/FluidNoveltyFeature.sc
@@ -1,11 +1,11 @@
 FluidNoveltyFeature : FluidRTUGen {
 	*kr { arg in = 0, algorithm = 0, kernelSize = 3, filterSize = 1, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1, maxKernelSize, maxFilterSize;
 
-        maxKernelSize = maxKernelSize ? kernelSize;
-        maxFilterSize = maxFilterSize ? filterSize;
-        algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm)  ?? {
-            ("FluidNoveltySlice: % is not a recognised algorithm").format(algorithm);
-        };
+		maxKernelSize = maxKernelSize ? kernelSize;
+		maxFilterSize = maxFilterSize ? filterSize;
+		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm)  ?? {
+			("FluidNoveltySlice: % is not a recognised algorithm").format(algorithm);
+		};
 
 		^this.multiNew('control', in.asAudioRateInput(this), algorithm, kernelSize, maxKernelSize, filterSize, maxFilterSize, windowSize, hopSize, fftSize, maxFFTSize)
 	}
@@ -13,16 +13,16 @@ FluidNoveltyFeature : FluidRTUGen {
 	checkInputs {
 		if([\scalar, \control].includes(inputs.at(1).rate).not) {
 			^(": invalid algorithm");
-		    };
+		};
 		if(inputs.at(9).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
-			};
+		};
 		if(inputs.at(3).rate != 'scalar') {
 			^(": maxKernelSize cannot be modulated.");
-			};
+		};
 		if(inputs.at(5).rate != 'scalar') {
 			^(": maxFilterSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidNoveltySlice.sc
+++ b/release-packaging/Classes/FluidNoveltySlice.sc
@@ -16,12 +16,12 @@ FluidNoveltySlice : FluidRTUGen {
 
 	*ar { arg in = 0, algorithm = 0, kernelSize = 3, threshold = 0.8, filterSize = 1, minSliceLength = 2, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1, maxKernelSize, maxFilterSize;
 
-        maxKernelSize = maxKernelSize ? kernelSize;
-        maxFilterSize = maxFilterSize ? filterSize;
+		maxKernelSize = maxKernelSize ? kernelSize;
+		maxFilterSize = maxFilterSize ? filterSize;
 
-        algorithm = this.prSelectAlgorithm(algorithm)  ?? {
-            ("FluidNoveltySlice: % is not a recognised algorithm").format(algorithm);
-        };
+		algorithm = this.prSelectAlgorithm(algorithm)  ?? {
+			("FluidNoveltySlice: % is not a recognised algorithm").format(algorithm);
+		};
 
 		^this.multiNew('audio', in.asAudioRateInput(this), algorithm, kernelSize, maxKernelSize, threshold, filterSize,  maxFilterSize, minSliceLength, windowSize, hopSize, fftSize, maxFFTSize)
 	}
@@ -29,16 +29,16 @@ FluidNoveltySlice : FluidRTUGen {
 	checkInputs {
 		if([\scalar, \control].includes(inputs.at(1).rate).not) {
 			^(": invalid algorithm");
-		    };
+		};
 		if(inputs.at(11).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
-			};
+		};
 		if(inputs.at(3).rate != 'scalar') {
 			^(": maxKernelSize cannot be modulated.");
-			};
+		};
 		if(inputs.at(6).rate != 'scalar') {
 			^(": maxFilterSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidOnsetFeature.sc
+++ b/release-packaging/Classes/FluidOnsetFeature.sc
@@ -10,10 +10,10 @@ FluidOnsetFeature : FluidRTUGen {
 	checkInputs {
 		if([\scalar, \control].includes(inputs.at(1).rate).not) {
 			^(": invalid metric");
-		    };
+		};
 		if(inputs.at(7).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidOnsetSlice.sc
+++ b/release-packaging/Classes/FluidOnsetSlice.sc
@@ -36,10 +36,10 @@ FluidOnsetSlice : FluidRTUGen {
 	checkInputs {
 		if([\scalar, \control].includes(inputs.at(1).rate).not) {
 			^(": invalid metric");
-		    };
+		};
 		if(inputs.at(9).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidPCA.sc
+++ b/release-packaging/Classes/FluidPCA.sc
@@ -1,62 +1,62 @@
 FluidPCA : FluidModelObject{
 
-    var <>numDimensions, <>whiten;
+	var <>numDimensions, <>whiten;
 
-    *new {|server, numDimensions = 2, whiten = 0|
+	*new {|server, numDimensions = 2, whiten = 0|
 		^super.new(server,[numDimensions, whiten]).numDimensions_(numDimensions).whiten_(whiten);
-    }
+	}
 
-    prGetParams{
-        ^[this.id, numDimensions, whiten];
-    }
+	prGetParams{
+		^[this.id, numDimensions, whiten];
+	}
 
-    fitMsg{|dataSet|
-        ^this.prMakeMsg(\fit,id, dataSet.id);
-    }
+	fitMsg{|dataSet|
+		^this.prMakeMsg(\fit,id, dataSet.id);
+	}
 
-    fit{|dataSet, action|
-        actions[\fit] = [nil, action];
-        this.prSendMsg(this.fitMsg(dataSet));
-    }
+	fit{|dataSet, action|
+		actions[\fit] = [nil, action];
+		this.prSendMsg(this.fitMsg(dataSet));
+	}
 
-    transformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\transform, id, sourceDataSet.id, destDataSet.id);
-    }
+	transformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\transform, id, sourceDataSet.id, destDataSet.id);
+	}
 
-    transform{|sourceDataSet, destDataSet, action|
-        actions[\transform] = [numbers(FluidMessageResponse,_,1,_),action];
-        this.prSendMsg(this.transformMsg(sourceDataSet,destDataSet));
-    }
+	transform{|sourceDataSet, destDataSet, action|
+		actions[\transform] = [numbers(FluidMessageResponse,_,1,_),action];
+		this.prSendMsg(this.transformMsg(sourceDataSet,destDataSet));
+	}
 
-    fitTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\fitTransform,id, sourceDataSet.id, destDataSet.id);
-    }
+	fitTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\fitTransform,id, sourceDataSet.id, destDataSet.id);
+	}
 
-    fitTransform{|sourceDataSet, destDataSet, action|
-        actions[\fitTransform] = [numbers(FluidMessageResponse,_,1,_),action];
-    	this.prSendMsg(this.fitTransformMsg(sourceDataSet,destDataSet));
-    }
+	fitTransform{|sourceDataSet, destDataSet, action|
+		actions[\fitTransform] = [numbers(FluidMessageResponse,_,1,_),action];
+		this.prSendMsg(this.fitTransformMsg(sourceDataSet,destDataSet));
+	}
 
-    transformPointMsg{|sourceBuffer, destBuffer|
-        ^this.prMakeMsg(\transformPoint,id,
-            this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(destBuffer),
-            ["/b_query",destBuffer.asUGenInput]
-        );
-    }
+	transformPointMsg{|sourceBuffer, destBuffer|
+		^this.prMakeMsg(\transformPoint,id,
+			this.prEncodeBuffer(sourceBuffer),
+			this.prEncodeBuffer(destBuffer),
+			["/b_query",destBuffer.asUGenInput]
+		);
+	}
 
-    transformPoint{|sourceBuffer, destBuffer, action|
-        actions[\transformPoint] = [nil,{action.value(destBuffer)}];
-        this.prSendMsg(this.transformPointMsg(sourceBuffer,destBuffer));
-    }
+	transformPoint{|sourceBuffer, destBuffer, action|
+		actions[\transformPoint] = [nil,{action.value(destBuffer)}];
+		this.prSendMsg(this.transformPointMsg(sourceBuffer,destBuffer));
+	}
 
-    kr{|trig, inputBuffer,outputBuffer,numDimensions|
+	kr{|trig, inputBuffer,outputBuffer,numDimensions|
 
-        numDimensions = numDimensions ? this.numDimensions;
-        this.numDimensions_(numDimensions);
+		numDimensions = numDimensions ? this.numDimensions;
+		this.numDimensions_(numDimensions);
 
-        ^FluidPCAQuery.kr(trig ,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.numDimensions, this.whiten);
-    }
+		^FluidPCAQuery.kr(trig ,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), this.numDimensions, this.whiten);
+	}
 
 	inverseTransformPointMsg{|sourceBuffer, destBuffer|
 		^this.prMakeMsg(\inverseTransformPoint,id,
@@ -71,26 +71,26 @@ FluidPCA : FluidModelObject{
 		this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer,destBuffer));
 	}
 
-    inverseTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id, destDataSet.id);
-    }
+	inverseTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id, destDataSet.id);
+	}
 
-    inverseTransform{|sourceDataSet, destDataSet,action|
-        actions[\inverseTransform] = [nil,action];
-        this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
-    }
+	inverseTransform{|sourceDataSet, destDataSet,action|
+		actions[\inverseTransform] = [nil,action];
+		this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
+	}
 
 
 }
 
 FluidPCAQuery :  FluidRTMultiOutUGen {
-       *kr{ |trig, model, inputBuffer,outputBuffer,numDimensions, whiten|
-        ^this.multiNew('control',trig, model.asUGenInput,
-            numDimensions, whiten,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model, inputBuffer,outputBuffer,numDimensions, whiten|
+		^this.multiNew('control',trig, model.asUGenInput,
+			numDimensions, whiten,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidPitch.sc
+++ b/release-packaging/Classes/FluidPitch.sc
@@ -1,44 +1,44 @@
 FluidPitch : FluidRTMultiOutUGen {
 
-    const <features=#[\pitch, \confidence];
-    classvar featuresLookup;
+	const <features=#[\pitch, \confidence];
+	classvar featuresLookup;
 
-    *initClass {
-        featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
-    }
+	*initClass {
+		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
+	}
 
-    *prWarnUnrecognised {|sym| ("WARNING: FluidPitch -" + sym + "is not a recognised option").postln}
+	*prWarnUnrecognised {|sym| ("WARNING: FluidPitch -" + sym + "is not a recognised option").postln}
 
-    *prProcessSelect {|a|
-        var bits;
-        a.asBag.countsDo{|item,count,i|
-            if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-        };
-        bits = a.collect{ |sym|
-            (featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-        }.reduce{|x,y| x | y};
-        ^bits
-    }
+	*prProcessSelect {|a|
+		var bits;
+		a.asBag.countsDo{|item,count,i|
+			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
+		};
+		bits = a.collect{ |sym|
+			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
+		}.reduce{|x,y| x | y};
+		^bits
+	}
 
 
 	*kr { arg in = 0, select, algorithm = 2, minFreq = 20, maxFreq = 10000, unit = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
-        
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
-        
+
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+
 		^this.multiNew('control', in.asAudioRateInput(this), selectbits, algorithm, minFreq, maxFreq, unit, windowSize, hopSize, fftSize, maxFFTSize);
 	}
 
 	init {arg ...theInputs;
-        var numChannels;
+		var numChannels;
 		inputs = theInputs;
-        numChannels = inputs.at(1).asBinaryDigits.sum;
+		numChannels = inputs.at(1).asBinaryDigits.sum;
 		^this.initOutputs(numChannels,rate);
 	}
 
 	checkInputs {
 		if(inputs.at(9).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidRobustScale.sc
+++ b/release-packaging/Classes/FluidRobustScale.sc
@@ -1,95 +1,95 @@
 FluidRobustScale : FluidModelObject {
 
-    var <>low, <>high;
+	var <>low, <>high;
 
 	*new {|server, low = 25, high = 75|
 		^super.new(server,[low,high])
 		.low_(low).high_(high);
 	}
 
-    prGetParams{
-        ^[this.id,this.low,this.high];
-    }
+	prGetParams{
+		^[this.id,this.low,this.high];
+	}
 
 
-    fitMsg{|dataSet|
-        ^this.prMakeMsg(\fit,id,dataSet.id)
-    }
+	fitMsg{|dataSet|
+		^this.prMakeMsg(\fit,id,dataSet.id)
+	}
 
 	fit{|dataSet, action|
-        actions[\fit] = [nil,action];
+		actions[\fit] = [nil,action];
 		this.prSendMsg(this.fitMsg(dataSet));
 	}
 
-    transformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\transform,id,sourceDataSet.id,destDataSet.id);
-    }
+	transformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\transform,id,sourceDataSet.id,destDataSet.id);
+	}
 
 	transform{|sourceDataSet, destDataSet, action|
 		actions[\transform] = [nil,action];
-        this.prSendMsg(this.transformMsg(sourceDataSet, destDataSet));
+		this.prSendMsg(this.transformMsg(sourceDataSet, destDataSet));
 	}
 
-    fitTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\fitTransform,id,sourceDataSet.id,destDataSet.id)
-    }
+	fitTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\fitTransform,id,sourceDataSet.id,destDataSet.id)
+	}
 
 	fitTransform{|sourceDataSet, destDataSet, action|
-        actions[\fitTransform] = [nil,action];
+		actions[\fitTransform] = [nil,action];
 		this.prSendMsg(this.fitTransformMsg(sourceDataSet, destDataSet));
 	}
 
-    transformPointMsg{|sourceBuffer, destBuffer|
-        ^this.prMakeMsg(\transformPoint,id,
-            this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(destBuffer),
-            ["/b_query",destBuffer.asUGenInput]
-        );
-    }
-
-	transformPoint{|sourceBuffer, destBuffer, action|
-        actions[\transformPoint] = [nil,{action.value(destBuffer)}];
-        this.prSendMsg(this.transformPointMsg(sourceBuffer, destBuffer));
+	transformPointMsg{|sourceBuffer, destBuffer|
+		^this.prMakeMsg(\transformPoint,id,
+			this.prEncodeBuffer(sourceBuffer),
+			this.prEncodeBuffer(destBuffer),
+			["/b_query",destBuffer.asUGenInput]
+		);
 	}
 
-    inverseTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
-    }
+	transformPoint{|sourceBuffer, destBuffer, action|
+		actions[\transformPoint] = [nil,{action.value(destBuffer)}];
+		this.prSendMsg(this.transformPointMsg(sourceBuffer, destBuffer));
+	}
+
+	inverseTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
+	}
 
 	inverseTransform{|sourceDataSet, destDataSet, action|
 		actions[\inverseTransform] = [nil,action];
-        this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
+		this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
 	}
 
-    inverseTransformPointMsg{|sourceBuffer, destBuffer|
-        ^this.prMakeMsg(\inverseTransformPoint,id,
-            this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(destBuffer),
-            ["/b_query",destBuffer.asUGenInput]
-        );
-    }
+	inverseTransformPointMsg{|sourceBuffer, destBuffer|
+		^this.prMakeMsg(\inverseTransformPoint,id,
+			this.prEncodeBuffer(sourceBuffer),
+			this.prEncodeBuffer(destBuffer),
+			["/b_query",destBuffer.asUGenInput]
+		);
+	}
 
 	inverseTransformPoint{|sourceBuffer, destBuffer, action|
-        actions[\inverseRransformPoint] = [nil,{action.value(destBuffer)}];
-        this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
+		actions[\inverseRransformPoint] = [nil,{action.value(destBuffer)}];
+		this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer,invert = 0|
+	kr{|trig, inputBuffer,outputBuffer,invert = 0|
 
-        ^FluidRobustScaleQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), invert);
-    }
+		^FluidRobustScaleQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), invert);
+	}
 
 
 }
 
 FluidRobustScaleQuery : FluidRTMultiOutUGen {
-       *kr{ |trig, model, inputBuffer,outputBuffer,invert|
-        ^this.multiNew('control',trig, model.asUGenInput,
-            invert,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model, inputBuffer,outputBuffer,invert|
+		^this.multiNew('control',trig, model.asUGenInput,
+			invert,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidSKMeans.sc
+++ b/release-packaging/Classes/FluidSKMeans.sc
@@ -85,9 +85,9 @@ FluidSKMeans : FluidModelObject {
 	encodePointMsg{ |sourceBuffer, targetBuffer|
 		^this.prMakeMsg(\encodePoint, id,
 			this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(targetBuffer),
-            ["/b_query", targetBuffer.asUGenInput]);
-    }
+			this.prEncodeBuffer(targetBuffer),
+			["/b_query", targetBuffer.asUGenInput]);
+	}
 
 	encodePoint { |sourceBuffer, targetBuffer, action|
 		actions[\encodePoint] = [nil,{action.value(targetBuffer)}];
@@ -96,40 +96,40 @@ FluidSKMeans : FluidModelObject {
 
 	getMeansMsg{|dataSet| ^this.prMakeMsg(\getMeans, id, dataSet.asUGenInput) }
 
-    getMeans{ |dataSet, action|
-        actions[\getMeans] = [nil, action];
+	getMeans{ |dataSet, action|
+		actions[\getMeans] = [nil, action];
 		this.prSendMsg(this.getMeansMsg(dataSet));
 	}
 
 	setMeansMsg{|dataSet| ^this.prMakeMsg(\setMeans, id, dataSet.asUGenInput) }
 
-    setMeans{ |dataSet, action|
-        actions[\setMeans] = [nil, action];
+	setMeans{ |dataSet, action|
+		actions[\setMeans] = [nil, action];
 		this.prSendMsg(this.setMeansMsg(dataSet));
 	}
 
 	clearMsg{ ^this.prMakeMsg(\clear, id) }
 
-    clear{ |action|
-        actions[\clear] = [nil, action];
+	clear{ |action|
+		actions[\clear] = [nil, action];
 		this.prSendMsg(this.clearMsg);
 	}
 
 	kr{|trig, inputBuffer,outputBuffer|
-        ^FluidSKMeansQuery.kr(trig,
-            this,
-            this.prEncodeBuffer(inputBuffer),
-            this.prEncodeBuffer(outputBuffer));
+		^FluidSKMeansQuery.kr(trig,
+			this,
+			this.prEncodeBuffer(inputBuffer),
+			this.prEncodeBuffer(outputBuffer));
 	}
 }
 
 FluidSKMeansQuery : FluidRTMultiOutUGen {
 
-    *kr{ |trig, model,inputBuffer, outputBuffer |
-        ^this.multiNew('control',trig, model.asUGenInput,inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model,inputBuffer, outputBuffer |
+		^this.multiNew('control',trig, model.asUGenInput,inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidSTFTPass.sc
+++ b/release-packaging/Classes/FluidSTFTPass.sc
@@ -5,7 +5,7 @@ FluidSTFTPass : FluidRTUGen {
 	checkInputs {
 		if(inputs.at(4).rate != 'scalar') {
 			^": maxFFTSize cannot be modulated.";
-			};
+		};
 		^this.checkValidInputs
 	}
 }

--- a/release-packaging/Classes/FluidServerCache.sc
+++ b/release-packaging/Classes/FluidServerCache.sc
@@ -3,7 +3,7 @@ FluidProxyUgen : UGen {
 	var <>pluginname;
 
 	*kr { |pluginname...args|
-        args = args.collect{|x| x.asUGenInput}
+		args = args.collect{|x| x.asUGenInput}
 		^this.new1('control', pluginname,*args)
 	}
 
@@ -17,9 +17,9 @@ FluidProxyUgen : UGen {
 		^pluginname.asString;
 	}
 
-    poll{ |trig = 10, label, trigid = -1|
-        ^super.poll(trig, label ? this.name, trigid)
-    }
+	poll{ |trig = 10, label, trigid = -1|
+		^super.poll(trig, label ? this.name, trigid)
+	}
 }
 
 FluidServerCache {
@@ -36,17 +36,17 @@ FluidServerCache {
 		cache[server]!?{cache[server].do{|x|func.value(x)}}
 	}
 
-    doAll {|func|
-        cache.do{|subCache|
-            subCache.do{|item|
-                func.value(item)
-            }
-        }
-    }
+	doAll {|func|
+		cache.do{|subCache|
+			subCache.do{|item|
+				func.value(item)
+			}
+		}
+	}
 
-    postln{
-        cache.postln;
-    }
+	postln{
+		cache.postln;
+	}
 
 	at { |server,id|
 		^cache[server].tryPerform(\at,id)
@@ -68,7 +68,7 @@ FluidServerCache {
 		cache[server] ?? {
 			cache[server] = IdentityDictionary.new;
 			NotificationCenter.register(server,\newAllocators,this,
-			{
+				{
 					this.clearCache(server);
 			});
 		}
@@ -76,18 +76,18 @@ FluidServerCache {
 
 	clearCache { |server|
 		cache[server] !?
-        {
-            var bundle = [];
-            cache[server].values.do{|i|
-                if(i.respondsTo(\freeMsg)){
-                    bundle = bundle.add(i.freeMsg); //server objects
-                }{
-                 i.free; //OSCFunc
-                }
-            };
-            server.listSendBundle(nil,bundle);
-            cache.removeAt(server);
-        };
+		{
+			var bundle = [];
+			cache[server].values.do{|i|
+				if(i.respondsTo(\freeMsg)){
+					bundle = bundle.add(i.freeMsg); //server objects
+				}{
+					i.free; //OSCFunc
+				}
+			};
+			server.listSendBundle(nil,bundle);
+			cache.removeAt(server);
+		};
 	}
 
 }

--- a/release-packaging/Classes/FluidServerObject.sc
+++ b/release-packaging/Classes/FluidServerObject.sc
@@ -1,346 +1,346 @@
 FluidServerObject
 {
-    classvar serverCaches;
-    classvar count;
-    classvar persistent = true;
-    var <server,<id;
+	classvar serverCaches;
+	classvar count;
+	classvar persistent = true;
+	var <server,<id;
 
-    *version{|server|
-        server ?? {server = Server.default};
-        server.sendMsg("/cmd","/"++this.objectClassName++'/version');
-    }
+	*version{|server|
+		server ?? {server = Server.default};
+		server.sendMsg("/cmd","/"++this.objectClassName++'/version');
+	}
 
-    *initClass {
-        serverCaches = IdentityDictionary.new;
-        count = 0;
-        ServerBoot.add({serverCaches[this]!?{serverCaches[this].cache.put(Server.internal,nil);}},Server.internal);
-    }
+	*initClass {
+		serverCaches = IdentityDictionary.new;
+		count = 0;
+		ServerBoot.add({serverCaches[this]!?{serverCaches[this].cache.put(Server.internal,nil);}},Server.internal);
+	}
 
-    *initCache {|server|
-        serverCaches[this] ?? { serverCaches[this] = FluidServerCache.new};
+	*initCache {|server|
+		serverCaches[this] ?? { serverCaches[this] = FluidServerCache.new};
 
-        if(server === Server.internal and: serverCaches[this].cache[Server.internal].isNil)
-        {
-            this.flush(Server.internal)
-        };
+		if(server === Server.internal and: serverCaches[this].cache[Server.internal].isNil)
+		{
+			this.flush(Server.internal)
+		};
 
-        serverCaches[this].initCache(server);
-        NotificationCenter.register(server,\newAllocators,this,{ count = 0; });
-    }
+		serverCaches[this].initCache(server);
+		NotificationCenter.register(server,\newAllocators,this,{ count = 0; });
+	}
 
-    *newMsg{|id, params|
-        params = params !? {params.collect(_.asUGenInput)};
-        ^this.prMakeMsg(\new,id,*params);
-    }
+	*newMsg{|id, params|
+		params = params !? {params.collect(_.asUGenInput)};
+		^this.prMakeMsg(\new,id,*params);
+	}
 
-    *new{ |server, id, params, action, callNew = true|
-        var newObj;
-        server ?? {server = Server.default};
-        if(server.serverRunning.not){"Server not running".warn};
-        id !? { id = id.asInteger }
-           ?? { id = count; count = count + 1; };
-        newObj = super.newCopyArgs(server,id,action);
-        // params.postln;
-        if(callNew) {server.listSendMsg(this.newMsg(id,params))};
-        ^newObj.cache
-    }
+	*new{ |server, id, params, action, callNew = true|
+		var newObj;
+		server ?? {server = Server.default};
+		if(server.serverRunning.not){"Server not running".warn};
+		id !? { id = id.asInteger }
+		?? { id = count; count = count + 1; };
+		newObj = super.newCopyArgs(server,id,action);
+		// params.postln;
+		if(callNew) {server.listSendMsg(this.newMsg(id,params))};
+		^newObj.cache
+	}
 
-    cache {
-        this.class.initCache(server);
-        serverCaches[this.class].put(server,this.id,this);
-    }
+	cache {
+		this.class.initCache(server);
+		serverCaches[this.class].put(server,this.id,this);
+	}
 
-    uncache{
-        serverCaches[this.class].remove(server,id);
-    }
+	uncache{
+		serverCaches[this.class].remove(server,id);
+	}
 
-    *prMakeMsg{|msg,id...args|
-        var commandName = "%/%".format(this.objectClassName,msg);
-        ^['/cmd', this.objectClassName,commandName,id].addAll(args);
-    }
+	*prMakeMsg{|msg,id...args|
+		var commandName = "%/%".format(this.objectClassName,msg);
+		^['/cmd', this.objectClassName,commandName,id].addAll(args);
+	}
 
-    prMakeMsg{|msg,id...args| ^this.class.prMakeMsg(msg,id,*args) }
+	prMakeMsg{|msg,id...args| ^this.class.prMakeMsg(msg,id,*args) }
 
-    freeMsg {
-        var msg;
-        id ?? {" % already freed".format(this.class.name).warn; ^nil};
-        this.uncache;
-        msg = this.prMakeMsg(\free,id);
-        id = nil;
-        ^msg;
-    }
+	freeMsg {
+		var msg;
+		id ?? {" % already freed".format(this.class.name).warn; ^nil};
+		this.uncache;
+		msg = this.prMakeMsg(\free,id);
+		id = nil;
+		^msg;
+	}
 
-    free{
-        var msg = this.freeMsg;
-        msg !? {server.listSendMsg(msg)} ?? {^nil};
-    }
+	free{
+		var msg = this.freeMsg;
+		msg !? {server.listSendMsg(msg)} ?? {^nil};
+	}
 
-    *freeAll{|server|
-        serverCaches[this] !? {|cache|
-            cache.clearCache(server ? Server.default);
-        };
-        count = 0;
-    }
+	*freeAll{|server|
+		serverCaches[this] !? {|cache|
+			cache.clearCache(server ? Server.default);
+		};
+		count = 0;
+	}
 
-    asUGenInput{ ^id }
+	asUGenInput{ ^id }
 
-    asString {
-        ^"%(%)".format(this.class.name,id).asString;
-    }
+	asString {
+		^"%(%)".format(this.class.name,id).asString;
+	}
 
-    asSymbol {
-        ^id.asSymbol
-    }
+	asSymbol {
+		^id.asSymbol
+	}
 
-    *objectClassName { ^this.name.asSymbol }
+	*objectClassName { ^this.name.asSymbol }
 
-    *flushMsg { ^['/cmd',this.objectClassName ++ '/flush'] }
+	*flushMsg { ^['/cmd',this.objectClassName ++ '/flush'] }
 
-    *flush {|server| server.listSendMsg(this.flushMsg)}
+	*flush {|server| server.listSendMsg(this.flushMsg)}
 }
 
 FluidBufProcessor : FluidServerObject
 {
-    var <processAction;
-    var <outputBuffers;
-    var <freeWhenDone;
-    classvar responder;
-    classvar count;
+	var <processAction;
+	var <outputBuffers;
+	var <freeWhenDone;
+	classvar responder;
+	classvar count;
 
-    *cmdPeriod {
-        serverCaches[this] !? {|cache|
-            cache.doAll{|processor| processor !? { processor.free;} };
-            serverCaches[this] = nil;
-        };
-        count = 0;
-    }
+	*cmdPeriod {
+		serverCaches[this] !? {|cache|
+			cache.doAll{|processor| processor !? { processor.free;} };
+			serverCaches[this] = nil;
+		};
+		count = 0;
+	}
 
-    *initCache {|server|
-        // "initcache".postln;
-        // this.done.postln;
-        super.initCache(server);
-        CmdPeriod.add(this);
-        if(serverCaches[this].includesKey(server,\processResponder).not)
-        {
-            serverCaches[this].put(server,\processResponder,OSCFunc({|m|
-                var id = m.last.asInteger;
-                // "I'm in the pizza hut".postln;
-                serverCaches[this].at(server,id) !? {|p|
-                    // "I'm in the taco bell".postln ;
-                    p!?{
-                        p.processAction!?{|a|
-                            var bufs = p.outputBuffers;
+	*initCache {|server|
+		// "initcache".postln;
+		// this.done.postln;
+		super.initCache(server);
+		CmdPeriod.add(this);
+		if(serverCaches[this].includesKey(server,\processResponder).not)
+		{
+			serverCaches[this].put(server,\processResponder,OSCFunc({|m|
+				var id = m.last.asInteger;
+				// "I'm in the pizza hut".postln;
+				serverCaches[this].at(server,id) !? {|p|
+					// "I'm in the taco bell".postln ;
+					p!?{
+						p.processAction!?{|a|
+							var bufs = p.outputBuffers;
 
-                            bufs = bufs.collect{|b|
-                                if(b.isKindOf(Buffer))
-                                {b}
-                                {Buffer.cachedBufferAt(server,b)};
-                            };
-                            a.valueArray(valueArray(bufs));
-                        };
-                        if(p.freeWhenDone){p.free};
-                    }
-                }
-            },this.done ,server.addr).fix)
-        }
-    }
+							bufs = bufs.collect{|b|
+								if(b.isKindOf(Buffer))
+								{b}
+								{Buffer.cachedBufferAt(server,b)};
+							};
+							a.valueArray(valueArray(bufs));
+						};
+						if(p.freeWhenDone){p.free};
+					}
+				}
+			},this.done ,server.addr).fix)
+		}
+	}
 
-    *new {|server,id,outputBuffers|
-        ^super.new(server,id, nil, nil,false).init(outputBuffers);
-    }
+	*new {|server,id,outputBuffers|
+		^super.new(server,id, nil, nil,false).init(outputBuffers);
+	}
 
-    init{ |ob|
-        outputBuffers = ob;
-    }
+	init{ |ob|
+		outputBuffers = ob;
+	}
 
-    *done {
-        ^"/%/process".format(this.objectClassName);
-    }
+	*done {
+		^"/%/process".format(this.objectClassName);
+	}
 
-    wait {
-        var condition = Condition.new;
-        id ?? {Error("% already freed".format(this.class.name)).throw};
-        OSCFunc({
-            condition.unhang;
-        },this.class.done,server.addr,argTemplate:[nil,id]).oneShot;
-        condition.hang;
-    }
+	wait {
+		var condition = Condition.new;
+		id ?? {Error("% already freed".format(this.class.name)).throw};
+		OSCFunc({
+			condition.unhang;
+		},this.class.done,server.addr,argTemplate:[nil,id]).oneShot;
+		condition.hang;
+	}
 
-    processMsg {|params|
-        var msg;
-        var completionMsg = outputBuffers !?    {
-            [["/sync"]] ++ outputBuffers.collect{|b| ["/b_query", b.asUGenInput]}
-        } ?? {[]};
+	processMsg {|params|
+		var msg;
+		var completionMsg = outputBuffers !?    {
+			[["/sync"]] ++ outputBuffers.collect{|b| ["/b_query", b.asUGenInput]}
+		} ?? {[]};
 
-        // completionMsg.postln;
-        id ?? {Error("% already freed".format(this.class.name)).throw};
-        msg = this.prMakeMsg(\processNew,id).addAll(params).add(completionMsg);
-        // msg.postln;
-        ^msg;
-    }
+		// completionMsg.postln;
+		id ?? {Error("% already freed".format(this.class.name)).throw};
+		msg = this.prMakeMsg(\processNew,id).addAll(params).add(completionMsg);
+		// msg.postln;
+		^msg;
+	}
 
-    processList { |params,shouldFree,action|
-        freeWhenDone = shouldFree;
-        processAction = action;
-        params = params.collect(_.asUGenInput);
-        server.listSendMsg(this.processMsg(params));
-    }
+	processList { |params,shouldFree,action|
+		freeWhenDone = shouldFree;
+		processAction = action;
+		params = params.collect(_.asUGenInput);
+		server.listSendMsg(this.processMsg(params));
+	}
 
-    cancelMsg{
-        id ?? {Error("% already freed".format(this.class.name)).throw};
-        ^this.prMakeMsg(\cancel, id);
-    }
+	cancelMsg{
+		id ?? {Error("% already freed".format(this.class.name)).throw};
+		^this.prMakeMsg(\cancel, id);
+	}
 
-    cancel{
-        server.listSendMsg(this.cancelMsg);
-    }
+	cancel{
+		server.listSendMsg(this.cancelMsg);
+	}
 
-    kr{  ^FluidProxyUgen.kr(this.class.objectClassName ++ "Monitor",id) }
+	kr{  ^FluidProxyUgen.kr(this.class.objectClassName ++ "Monitor",id) }
 }
 
 FluidOSCPatternInversion : OSCMessageDispatcher
 {
-    value {|msg, time, addr, recvPort|
-        var msgpath = msg[0].asSymbol;
-        active.keysValuesDo({|key, func|
-            if(msgpath.matchOSCAddressPattern(key), {func.value(msg, time, addr, recvPort);});
-        })
-    }
+	value {|msg, time, addr, recvPort|
+		var msgpath = msg[0].asSymbol;
+		active.keysValuesDo({|key, func|
+			if(msgpath.matchOSCAddressPattern(key), {func.value(msg, time, addr, recvPort);});
+		})
+	}
 }
 
 
 FluidDataObject : FluidServerObject
 {
-    classvar postResponse;
+	classvar postResponse;
 
-    var <actions;
+	var <actions;
 
-    *initClass{
-        postResponse = _.postln;
-    }
+	*initClass{
+		postResponse = _.postln;
+	}
 
-    *initCache{ |server|
-        super.initCache(server);
-        if(serverCaches[this].includesKey(server,\messageResponder).not)
-        {
-            serverCaches[this].put(server,\messageResponder,OSCFunc.new({|m|
-                var id = m[1].asInteger;
-                var method;
-                serverCaches[this].at(server,id) !? { |p|
-                    method = m[0].asString.findRegexp("/"++this.name++"/(.*)")[1][1].asSymbol;
-                    p.actions[method] !? {|a|
-                        //two items: parser and action
-                        var parser = a[0];
-                        var action = a[1];
-                        var result = FluidMessageResponse.collectArgs(parser,m[2..]);
-                        action.value(result);
-                    }
-                }
-            },'/' ++ this.objectClassName ++ '/*',server.addr, dispatcher:FluidOSCPatternInversion.new).fix)
-        }
-    }
+	*initCache{ |server|
+		super.initCache(server);
+		if(serverCaches[this].includesKey(server,\messageResponder).not)
+		{
+			serverCaches[this].put(server,\messageResponder,OSCFunc.new({|m|
+				var id = m[1].asInteger;
+				var method;
+				serverCaches[this].at(server,id) !? { |p|
+					method = m[0].asString.findRegexp("/"++this.name++"/(.*)")[1][1].asSymbol;
+					p.actions[method] !? {|a|
+						//two items: parser and action
+						var parser = a[0];
+						var action = a[1];
+						var result = FluidMessageResponse.collectArgs(parser,m[2..]);
+						action.value(result);
+					}
+				}
+			},'/' ++ this.objectClassName ++ '/*',server.addr, dispatcher:FluidOSCPatternInversion.new).fix)
+		}
+	}
 
-    *new{|server...args|
-        // args.flatten.postln;
-        ^super.new(server,params:args.flatten).init;
-    }
+	*new{|server...args|
+		// args.flatten.postln;
+		^super.new(server,params:args.flatten).init;
+	}
 
-    *cachedInstanceAt{|server,id|
-        this.initCache(server);
-        ^serverCaches[this].at(server,id);
-    }
+	*cachedInstanceAt{|server,id|
+		this.initCache(server);
+		^serverCaches[this].at(server,id);
+	}
 
-    init {
-        actions = IdentityDictionary.new;
-    }
+	init {
+		actions = IdentityDictionary.new;
+	}
 
-    prEncodeBuffer { |buf| buf !? {^buf.asUGenInput} ?? {^-1} }
+	prEncodeBuffer { |buf| buf !? {^buf.asUGenInput} ?? {^-1} }
 
-    prSendMsg {|msg| server !? {server.listSendMsg(msg)};}
+	prSendMsg {|msg| server !? {server.listSendMsg(msg)};}
 
-    colsMsg { ^this.prMakeMsg(\cols,id);}
+	colsMsg { ^this.prMakeMsg(\cols,id);}
 
-    cols{ |action=(postResponse)|
-        actions[\cols] = [numbers(FluidMessageResponse,_,1,_),action];
-        this.prSendMsg(this.colsMsg)
-    }
+	cols{ |action=(postResponse)|
+		actions[\cols] = [numbers(FluidMessageResponse,_,1,_),action];
+		this.prSendMsg(this.colsMsg)
+	}
 
-    readMsg { |filename| ^this.prMakeMsg(\read,id,filename.asString);}
+	readMsg { |filename| ^this.prMakeMsg(\read,id,filename.asString);}
 
-    read{|filename, action|
-      actions[\read] = [nil,action];
-      this.prSendMsg(this.readMsg(filename));
-    }
+	read{|filename, action|
+		actions[\read] = [nil,action];
+		this.prSendMsg(this.readMsg(filename));
+	}
 
-    writeMsg {|filename|
-        // ^['/cmd',this.class.name ++ '/write',id,filename.asString]
-        ^this.prMakeMsg(\write,id,filename.asString);
-    }
+	writeMsg {|filename|
+		// ^['/cmd',this.class.name ++ '/write',id,filename.asString]
+		^this.prMakeMsg(\write,id,filename.asString);
+	}
 
-    write{|filename, action|
-      actions[\write] = [nil,action];
-      this.prSendMsg(this.writeMsg(filename));
-    }
+	write{|filename, action|
+		actions[\write] = [nil,action];
+		this.prSendMsg(this.writeMsg(filename));
+	}
 
-    sizeMsg{
-        // ^['/cmd',this.class.name ++ '/size',id]
-        ^this.prMakeMsg(\size,id);
-    }
+	sizeMsg{
+		// ^['/cmd',this.class.name ++ '/size',id]
+		^this.prMakeMsg(\size,id);
+	}
 
-    size {|action=(postResponse)|
-      actions[\size] = [numbers(FluidMessageResponse,_,1,_),action];
-      this.prSendMsg(this.sizeMsg);
-    }
+	size {|action=(postResponse)|
+		actions[\size] = [numbers(FluidMessageResponse,_,1,_),action];
+		this.prSendMsg(this.sizeMsg);
+	}
 }
 
 FluidModelObject : FluidDataObject
 {
-    prGetParams{
-        "Subclass should provide this".throw;
-    }
+	prGetParams{
+		"Subclass should provide this".throw;
+	}
 
-    prUpdateStateMsg{
-        var params = this.prGetParams.value.collect(_.asUGenInput);
-        ^this.prMakeMsg(\setParams,id) ++ params;
-    }
+	prUpdateStateMsg{
+		var params = this.prGetParams.value.collect(_.asUGenInput);
+		^this.prMakeMsg(\setParams,id) ++ params;
+	}
 
-    prSendMsg {|msg|
-        //These need to happen sequentially, but not simultaneously
-        //sending as a bundle makes reasoning about timing w/r/t other
-        //commands more awkward, unless we set the offet to 0 (in which case,
-        //noisy 'late' messages)
-        super.prSendMsg(this.prUpdateStateMsg);
-        super.prSendMsg(msg);
-    }
+	prSendMsg {|msg|
+		//These need to happen sequentially, but not simultaneously
+		//sending as a bundle makes reasoning about timing w/r/t other
+		//commands more awkward, unless we set the offet to 0 (in which case,
+		//noisy 'late' messages)
+		super.prSendMsg(this.prUpdateStateMsg);
+		super.prSendMsg(msg);
+	}
 }
 
 FluidRealTimeModel : FluidModelObject
 {
-    *new{ |server, params|
-        ^super.new(server,params++[-1,-1]);
-    }
+	*new{ |server, params|
+		^super.new(server,params++[-1,-1]);
+	}
 }
 
 FluidRTQuery : FluidProxyUgen
 {
-    *kr{ |trig,obj...args|
-        ^super.kr(this.name,trig,obj.asUGenInput, *args)
-    }
+	*kr{ |trig,obj...args|
+		^super.kr(this.name,trig,obj.asUGenInput, *args)
+	}
 }
 
 
 FluidRTUGen : UGen
 {
-    *version{|server|
-        server ?? {server = Server.default};
-        server.sendMsg("/cmd","/"++this.name++'/version');
-    }
+	*version{|server|
+		server ?? {server = Server.default};
+		server.sendMsg("/cmd","/"++this.name++'/version');
+	}
 }
 
 FluidRTMultiOutUGen : MultiOutUGen
 {
-    *version{|server|
-        server ?? {server = Server.default};
-        server.sendMsg("/cmd","/"++this.name++'/version');
-    }
+	*version{|server|
+		server ?? {server = Server.default};
+		server.sendMsg("/cmd","/"++this.name++'/version');
+	}
 }

--- a/release-packaging/Classes/FluidSines.sc
+++ b/release-packaging/Classes/FluidSines.sc
@@ -13,7 +13,7 @@ FluidSines : FluidRTMultiOutUGen {
 	checkInputs {
 		if(inputs.at(13).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
-			};
+		};
 		^this.checkNInputs(1)
 	}
 }

--- a/release-packaging/Classes/FluidSpectralShape.sc
+++ b/release-packaging/Classes/FluidSpectralShape.sc
@@ -1,44 +1,44 @@
 FluidSpectralShape : FluidRTMultiOutUGen {
 
-    const <features=#[\centroid,\spread,\skewness,\kurtosis,\rolloff,\flatness,\crest];
-    classvar featuresLookup;
+	const <features=#[\centroid,\spread,\skewness,\kurtosis,\rolloff,\flatness,\crest];
+	classvar featuresLookup;
 
-    *initClass {
-        featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
-    }
+	*initClass {
+		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
+	}
 
-    *prWarnUnrecognised {|sym| ("WARNING: FluidSpectralShape -" + sym + "is not a recognised option").postln}
+	*prWarnUnrecognised {|sym| ("WARNING: FluidSpectralShape -" + sym + "is not a recognised option").postln}
 
-    *prProcessSelect {|a|
-        var bits;
-        a.asBag.countsDo{|item,count,i|
-            if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-        };
-        bits = a.collect{ |sym|
-            (featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-        }.reduce{|x,y| x | y};
-        ^bits
-    }
+	*prProcessSelect {|a|
+		var bits;
+		a.asBag.countsDo{|item,count,i|
+			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
+		};
+		bits = a.collect{ |sym|
+			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
+		}.reduce{|x,y| x | y};
+		^bits
+	}
 
 
-    *kr { arg in = 0, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
+	*kr { arg in = 0, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
 
-        var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
 
-        ^this.multiNew('control', in.asAudioRateInput(this), selectbits, minFreq, maxFreq, rolloffPercent, unit, power, windowSize, hopSize, fftSize, maxFFTSize);
+		^this.multiNew('control', in.asAudioRateInput(this), selectbits, minFreq, maxFreq, rolloffPercent, unit, power, windowSize, hopSize, fftSize, maxFFTSize);
 	}
 
 	init {arg ...theInputs;
-        var numChannels;
+		var numChannels;
 		inputs = theInputs;
-        numChannels = inputs.at(1).asBinaryDigits.sum;
+		numChannels = inputs.at(1).asBinaryDigits.sum;
 		^this.initOutputs(numChannels,rate);
 	}
 
 	checkInputs {
 		if(inputs.at(10).rate != 'scalar') {
 			^(": maxFFTSize cannot be modulated.");
-			};
+		};
 		^this.checkValidInputs;
 	}
 }

--- a/release-packaging/Classes/FluidStandardize.sc
+++ b/release-packaging/Classes/FluidStandardize.sc
@@ -1,86 +1,86 @@
 FluidStandardize : FluidModelObject {
 
-    *new {|server|
+	*new {|server|
 		^super.new(server,[]);
 	}
 
-    prGetParams{
-        ^[this.id];
-    }
+	prGetParams{
+		^[this.id];
+	}
 
 	fitMsg{|dataSet|
-        ^this.prMakeMsg(\fit,id,dataSet.id);
-    }
+		^this.prMakeMsg(\fit,id,dataSet.id);
+	}
 
-    fit{|dataSet, action|
-        actions[\fit] = [nil, action];
+	fit{|dataSet, action|
+		actions[\fit] = [nil, action];
 		this.prSendMsg(this.fitMsg(dataSet));
 	}
 
 	transformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\transform,id,sourceDataSet.id,destDataSet.id);
-    }
+		^this.prMakeMsg(\transform,id,sourceDataSet.id,destDataSet.id);
+	}
 
 	transform{|sourceDataSet, destDataSet, action|
-        actions[\transform] = [nil,action];
+		actions[\transform] = [nil,action];
 		this.prSendMsg(this.transformMsg(sourceDataSet,destDataSet));
 	}
 
-    fitTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\fitTransform,id,sourceDataSet.id,destDataSet.id)
-    }
+	fitTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\fitTransform,id,sourceDataSet.id,destDataSet.id)
+	}
 
 	fitTransform{|sourceDataSet, destDataSet, action|
-        actions[\fitTransform] = [nil,action];
+		actions[\fitTransform] = [nil,action];
 		this.prSendMsg(this.fitTransformMsg(sourceDataSet, destDataSet));
 	}
 
 
-    transformPointMsg{|sourceBuffer, destBuffer|
-        ^this.prMakeMsg(\transformPoint, id, this.prEncodeBuffer(sourceBuffer), this.prEncodeBuffer(destBuffer),["/b_query",destBuffer.asUGenInput]);
-    }
-
-	transformPoint{|sourceBuffer, destBuffer, action|
-        actions[\transformPoint] = [nil, {action.value(destBuffer)}];
-        this.prSendMsg(this.transformPointMsg(sourceBuffer,destBuffer));
+	transformPointMsg{|sourceBuffer, destBuffer|
+		^this.prMakeMsg(\transformPoint, id, this.prEncodeBuffer(sourceBuffer), this.prEncodeBuffer(destBuffer),["/b_query",destBuffer.asUGenInput]);
 	}
 
-    inverseTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
-    }
+	transformPoint{|sourceBuffer, destBuffer, action|
+		actions[\transformPoint] = [nil, {action.value(destBuffer)}];
+		this.prSendMsg(this.transformPointMsg(sourceBuffer,destBuffer));
+	}
+
+	inverseTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\inverseTransform,id,sourceDataSet.id,destDataSet.id);
+	}
 
 	inverseTransform{|sourceDataSet, destDataSet, action|
 		actions[\inverseTransform] = [nil,action];
-        this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
+		this.prSendMsg(this.inverseTransformMsg(sourceDataSet, destDataSet));
 	}
 
-    inverseTransformPointMsg{|sourceBuffer, destBuffer|
-        ^this.prMakeMsg(\inverseTransformPoint,id,
-            this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(destBuffer),
-            ["/b_query",destBuffer.asUGenInput]
-        );
-    }
+	inverseTransformPointMsg{|sourceBuffer, destBuffer|
+		^this.prMakeMsg(\inverseTransformPoint,id,
+			this.prEncodeBuffer(sourceBuffer),
+			this.prEncodeBuffer(destBuffer),
+			["/b_query",destBuffer.asUGenInput]
+		);
+	}
 
 	inverseTransformPoint{|sourceBuffer, destBuffer, action|
-        actions[\inverseRransformPoint] = [nil,{action.value(destBuffer)}];
-        this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
+		actions[\inverseRransformPoint] = [nil,{action.value(destBuffer)}];
+		this.prSendMsg(this.inverseTransformPointMsg(sourceBuffer, destBuffer));
 	}
 
-    kr{|trig, inputBuffer,outputBuffer,invert = 0|
+	kr{|trig, inputBuffer,outputBuffer,invert = 0|
 
-        ^FluidStandardizeQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), invert);
-    }
+		^FluidStandardizeQuery.kr(trig,this, this.prEncodeBuffer(inputBuffer), this.prEncodeBuffer(outputBuffer), invert);
+	}
 }
 
 FluidStandardizeQuery : FluidRTMultiOutUGen {
-   *kr{ |trig, model,inputBuffer,outputBuffer,invert = 0|
-        ^this.multiNew('control',trig, model.asUGenInput,
-            invert,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model,inputBuffer,outputBuffer,invert = 0|
+		^this.multiNew('control',trig, model.asUGenInput,
+			invert,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidStats.sc
+++ b/release-packaging/Classes/FluidStats.sc
@@ -1,12 +1,12 @@
 FluidStats : MultiOutUGen {
 
 	*kr { arg in, history;
-        ^this.multiNew('control',*(in.asArray++history)).reshape(2,in.asArray.size);
+		^this.multiNew('control',*(in.asArray++history)).reshape(2,in.asArray.size);
 	}
 
 	init {arg ...theInputs;
 		inputs = theInputs;
-        this.specialIndex = (inputs.size - 2).max(0);
+		this.specialIndex = (inputs.size - 2).max(0);
 		^this.initOutputs(inputs.size - 1,rate)
 	}
 
@@ -14,17 +14,17 @@ FluidStats : MultiOutUGen {
 		^this.checkValidInputs;
 	}
 
-    initOutputs{|numChans,rate|
-        if(numChans.isNil or: {numChans < 1})
-        {
-            Error("No input channels").throw
-        };
+	initOutputs{|numChans,rate|
+		if(numChans.isNil or: {numChans < 1})
+		{
+			Error("No input channels").throw
+		};
 
-        channels = Array.fill(numChans * 2, { |i|
-            OutputProxy('control',this,i);
-        });
-        ^channels
-    }
+		channels = Array.fill(numChans * 2, { |i|
+			OutputProxy('control',this,i);
+		});
+		^channels
+	}
 
-    numOutputs { ^(channels.size); }
+	numOutputs { ^(channels.size); }
 }

--- a/release-packaging/Classes/FluidUMAP.sc
+++ b/release-packaging/Classes/FluidUMAP.sc
@@ -1,75 +1,75 @@
 FluidUMAP : FluidModelObject {
 
-    var <>numDimensions, <>numNeighbours, <>minDist, <>iterations, <>learnRate;
+	var <>numDimensions, <>numNeighbours, <>minDist, <>iterations, <>learnRate;
 
 	*new {|server,numDimensions = 2, numNeighbours = 15, minDist = 0.1, iterations = 200, learnRate = 0.1|
 		^super.new(server,[numDimensions, numNeighbours, minDist, iterations, learnRate])
-        .numDimensions_(numDimensions)
-        .numNeighbours_(numNeighbours)
-        .minDist_(minDist)
-        .iterations_(iterations)
-        .learnRate_(learnRate);
+		.numDimensions_(numDimensions)
+		.numNeighbours_(numNeighbours)
+		.minDist_(minDist)
+		.iterations_(iterations)
+		.learnRate_(learnRate);
 	}
 
-    prGetParams{
-        ^[
-            this.id,
-            this.numDimensions,
-            this.numNeighbours,
-            this.minDist,
-            this.iterations,
-            this.learnRate,
-        ]
-    }
+	prGetParams{
+		^[
+			this.id,
+			this.numDimensions,
+			this.numNeighbours,
+			this.minDist,
+			this.iterations,
+			this.learnRate,
+		]
+	}
 
-    fitTransformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\fitTransform, id, sourceDataSet.id, destDataSet.id)
-    }
+	fitTransformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\fitTransform, id, sourceDataSet.id, destDataSet.id)
+	}
 
 	fitTransform{|sourceDataSet, destDataSet, action|
-        actions[\fitTransform] = [nil, action];
+		actions[\fitTransform] = [nil, action];
 		this.prSendMsg(this.fitTransformMsg(sourceDataSet,destDataSet));
 	}
 
 	fitMsg{|dataSet|
-        ^this.prMakeMsg(\fit,id, dataSet.id);
-    }
+		^this.prMakeMsg(\fit,id, dataSet.id);
+	}
 
-    fit{|dataSet, action|
-        actions[\fit] = [nil, action];
-        this.prSendMsg(this.fitMsg(dataSet));
-    }
+	fit{|dataSet, action|
+		actions[\fit] = [nil, action];
+		this.prSendMsg(this.fitMsg(dataSet));
+	}
 
-    transformMsg{|sourceDataSet, destDataSet|
-        ^this.prMakeMsg(\transform, id, sourceDataSet.id, destDataSet.id);
-    }
+	transformMsg{|sourceDataSet, destDataSet|
+		^this.prMakeMsg(\transform, id, sourceDataSet.id, destDataSet.id);
+	}
 
-    transform{|sourceDataSet, destDataSet, action|
-        actions[\transform] = [nil, action];
-        this.prSendMsg(this.transformMsg(sourceDataSet,destDataSet));
-    }
+	transform{|sourceDataSet, destDataSet, action|
+		actions[\transform] = [nil, action];
+		this.prSendMsg(this.transformMsg(sourceDataSet,destDataSet));
+	}
 
 
-    transformPointMsg{|sourceBuffer, destBuffer|
-        ^this.prMakeMsg(\transformPoint,id,
-            this.prEncodeBuffer(sourceBuffer),
-            this.prEncodeBuffer(destBuffer),
-            ["/b_query",destBuffer.asUGenInput]
-        );
-    }
+	transformPointMsg{|sourceBuffer, destBuffer|
+		^this.prMakeMsg(\transformPoint,id,
+			this.prEncodeBuffer(sourceBuffer),
+			this.prEncodeBuffer(destBuffer),
+			["/b_query",destBuffer.asUGenInput]
+		);
+	}
 
-    transformPoint{|sourceBuffer, destBuffer, action|
-        actions[\transformPoint] = [nil,{action.value(destBuffer)}];
-        this.prSendMsg(this.transformPointMsg(sourceBuffer,destBuffer));
-    }
+	transformPoint{|sourceBuffer, destBuffer, action|
+		actions[\transformPoint] = [nil,{action.value(destBuffer)}];
+		this.prSendMsg(this.transformPointMsg(sourceBuffer,destBuffer));
+	}
 
 	kr{|trig, inputBuffer,outputBuffer|
 
-        ^FluidUMAPQuery.kr(trig,
-            this,
+		^FluidUMAPQuery.kr(trig,
+			this,
 			this.prEncodeBuffer(inputBuffer),
 			this.prEncodeBuffer(outputBuffer));
-    }
+	}
 
 	// not implemented
 	cols {|action|}
@@ -77,12 +77,12 @@ FluidUMAP : FluidModelObject {
 }
 
 FluidUMAPQuery : FluidRTMultiOutUGen {
-    *kr{ |trig, model, inputBuffer,outputBuffer|
-        ^this.multiNew('control',trig, model.asUGenInput,
-            inputBuffer.asUGenInput, outputBuffer.asUGenInput)
-    }
+	*kr{ |trig, model, inputBuffer,outputBuffer|
+		^this.multiNew('control',trig, model.asUGenInput,
+			inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	}
 
-    init { arg ... theInputs;
+	init { arg ... theInputs;
 		inputs = theInputs;
 		^this.initOutputs(1, rate);
 	}

--- a/release-packaging/Classes/FluidWaveform.sc
+++ b/release-packaging/Classes/FluidWaveform.sc
@@ -433,5 +433,5 @@ FluidWaveform : FluidViewer {
 		};
 	}
 
-    asView { ^view }
+	asView { ^view }
 }


### PR DESCRIPTION
Sorry if you see this as pedantic, but I thought it would be nice to have uniform indentation in all SuperCollider files for this project! Many times I encountered files with mixed indentation, and I thought this could be a good time to make them uniform :)

SuperCollider code defaults to indentation using tabs. All sc files in the main codebase are formatted like this. 
Here I just opened every `.sc` file with `scide`, selected all code, and automatically indented it pressing Tab.

Since I'm not aware of any sc linter, I haven't considered any other style-guide rule (https://github.com/supercollider/supercollider/wiki/Code-style-guidelines#supercollider), only indentation and trailing white-spaces.