### PR TITLE
sclang: refactoring processSelect and validateBuffer

### DIFF
--- a/release-packaging/Classes/FluidBufAmpFeature.sc
+++ b/release-packaging/Classes/FluidBufAmpFeature.sc
@@ -2,22 +2,16 @@ FluidBufAmpFeature : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, trig = 1, blocking = 0|
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^FluidProxyUgen.kr(\FluidBufAmpFeatureTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, fastRampUp, fastRampDown, slowRampUp, slowRampDown, floor, highPassFreq, trig, blocking);
 	}
 
 	*process { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, freeWhenDone = true, action |
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(server, nil, [features]).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, fastRampUp, fastRampDown, slowRampUp, slowRampDown, floor, highPassFreq,0],freeWhenDone, action
@@ -26,11 +20,8 @@ FluidBufAmpFeature : FluidBufProcessor {
 
 	*processBlocking { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, floor = -144, highPassFreq = 85, freeWhenDone = true, action |
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufAmpFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufAmpFeature:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(server, nil, [features]).processList(
 			[source, startFrame, numFrames, startChan, numChans, features, fastRampUp, fastRampDown, slowRampUp, slowRampDown, floor, highPassFreq,1],freeWhenDone, action

--- a/release-packaging/Classes/FluidBufAmpGate.sc
+++ b/release-packaging/Classes/FluidBufAmpGate.sc
@@ -4,8 +4,8 @@ FluidBufAmpGate : FluidBufProcessor {
 
 		var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^FluidProxyUgen.kr(\FluidBufAmpGateTrigger,-1, source, startFrame, numFrames, startChan, numChans, indices, rampUp, rampDown, onThreshold, offThreshold, minSliceLength, minSilenceLength, minLengthAbove, minLengthBelow, lookBack, lookAhead, highPassFreq,maxSize,  trig, blocking);
 	}
@@ -15,8 +15,8 @@ FluidBufAmpGate : FluidBufProcessor {
 
 		var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
 
-		source = source ? -1;
-		indices = indices ? -1;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^this.new(
 			server, nil, [indices]
@@ -30,8 +30,8 @@ FluidBufAmpGate : FluidBufProcessor {
 
 		var maxSize = max(minLengthAbove + lookBack, max(minLengthBelow,lookAhead));
 
-		source = source ? -1;
-		indices = indices ? -1;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^this.new(
 			server, nil, [indices]

--- a/release-packaging/Classes/FluidBufAmpSlice.sc
+++ b/release-packaging/Classes/FluidBufAmpSlice.sc
@@ -2,22 +2,16 @@ FluidBufAmpSlice : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, trig = 1, blocking = 0|
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
-
-		source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^FluidProxyUgen.kr(\FluidBufAmpSliceTrigger, -1, source, startFrame, numFrames, startChan, numChans, indices, fastRampUp, fastRampDown, slowRampUp, slowRampDown, onThreshold, offThreshold, floor, minSliceLength, highPassFreq, trig, blocking);
 	}
 
 	*process { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, freeWhenDone = true, action |
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
-
-		source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^this.new(server, nil, [indices]).processList(
 			[source, startFrame, numFrames, startChan, numChans, indices, fastRampUp, fastRampDown, slowRampUp, slowRampDown, onThreshold, offThreshold, floor, minSliceLength, highPassFreq,0],freeWhenDone, action
@@ -26,11 +20,8 @@ FluidBufAmpSlice : FluidBufProcessor {
 
 	*processBlocking { |server,source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, fastRampUp = 1, fastRampDown = 1, slowRampUp = 100, slowRampDown = 100, onThreshold = -144, offThreshold = -144, floor = -144, minSliceLength = 2, highPassFreq = 85, freeWhenDone = true, action |
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
-
-		source.isNil.if {"FluidBufAmpSlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufAmpSlice:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^this.new(server, nil, [indices]).processList(
 			[source, startFrame, numFrames, startChan, numChans, indices, fastRampUp, fastRampDown, slowRampUp, slowRampDown, onThreshold, offThreshold, floor, minSliceLength, highPassFreq,1],freeWhenDone, action

--- a/release-packaging/Classes/FluidBufAudioTransport.sc
+++ b/release-packaging/Classes/FluidBufAudioTransport.sc
@@ -3,13 +3,9 @@ FluidBufAudioTransport : FluidBufProcessor {
 	*kr  { |sourceA, startFrameA = 0, numFramesA = -1, startChanA = 0, numChansA = -1, sourceB, startFrameB = 0, numFramesB = -1, startChanB = 0, numChansB = -1, destination, interpolation = 0.0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
-		sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
-		sourceA = sourceA.asUGenInput;
-		sourceB = sourceB.asUGenInput;
-
-		destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
-		destination = destination.asUGenInput;
+		sourceA = this.validateBuffer(sourceA, "source 1");
+		sourceB = this.validateBuffer(sourceB, "source 2");
+		destination = this.validateBuffer(destination, "destination");
 
 
 		^FluidProxyUgen.kr(this.objectClassName++\Trigger,-1, sourceA, startFrameA, numFramesA, startChanA, numChansA, sourceB, startFrameA, numFramesA, startChanB, numChansB, destination, interpolation, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
@@ -19,13 +15,9 @@ FluidBufAudioTransport : FluidBufProcessor {
 	*process { |server, sourceA, startFrameA = 0, numFramesA = -1, startChanA = 0, numChansA = -1, sourceB, startFrameB = 0, numFramesB = -1, startChanB = 0, numChansB = -1, destination, interpolation=0.0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
-		sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
-		sourceA = sourceA.asUGenInput;
-		sourceB = sourceB.asUGenInput;
-
-		destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
-		destination = destination.asUGenInput;
+		sourceA = this.validateBuffer(sourceA, "source 1");
+		sourceB = this.validateBuffer(sourceB, "source 2");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination]
@@ -37,13 +29,9 @@ FluidBufAudioTransport : FluidBufProcessor {
 	*processBlocking { |server, sourceA, startFrameA = 0, numFramesA = -1, startChanA = 0, numChansA = -1, sourceB, startFrameB = 0, numFramesB = -1, startChanB = 0, numChansB = -1, destination, interpolation=0.0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		sourceA.isNil.if {"FluidAudioTransport:  Invalid source 1 buffer".throw};
-		sourceB.isNil.if {"FluidAudioTransport:  Invalid source 2 buffer".throw};
-		sourceA = sourceA.asUGenInput;
-		sourceB = sourceB.asUGenInput;
-
-		destination.isNil.if {"FluidAudioTransport:  Invalid destination buffer".throw};
-		destination = destination.asUGenInput;
+		sourceA = this.validateBuffer(sourceA, "source 1");
+		sourceB = this.validateBuffer(sourceB, "source 2");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination]

--- a/release-packaging/Classes/FluidBufChroma.sc
+++ b/release-packaging/Classes/FluidBufChroma.sc
@@ -3,11 +3,8 @@ FluidBufChroma : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^FluidProxyUgen.kr(\FluidBufChromaTrigger,-1, source, startFrame, numFrames, startChan, numChans, features, padding, numChroma, numChroma, ref, normalize, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
@@ -16,11 +13,8 @@ FluidBufChroma : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]
@@ -33,11 +27,8 @@ FluidBufChroma : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufChroma:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufChroma:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufCompose.sc
+++ b/release-packaging/Classes/FluidBufCompose.sc
@@ -2,11 +2,8 @@ FluidBufCompose : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, gain = 1, destination, destStartFrame = 0, destStartChan = 0, destGain = 0, trig = 1, blocking = 1|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^FluidProxyUgen.kr(\FluidBufComposeTrigger,-1, source, startFrame, numFrames, startChan, numChans, gain, destination, destStartFrame, destStartChan, destGain, trig, blocking);
 	}
@@ -14,22 +11,16 @@ FluidBufCompose : FluidBufProcessor {
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, gain = 1, destination, destStartFrame = 0, destStartChan = 0, destGain = 0, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new( server, nil, [destination]).processList([source, startFrame, numFrames, startChan, numChans, gain, destination, destStartFrame, destStartChan, destGain, 1], freeWhenDone, action);//NB always blocking
 	}
 
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, gain = 1, destination, destStartFrame = 0, destStartChan = 0, destGain = 0, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufCompose:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufCompose:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination]

--- a/release-packaging/Classes/FluidBufFlatten.sc
+++ b/release-packaging/Classes/FluidBufFlatten.sc
@@ -3,22 +3,16 @@ FluidBufFlatten : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, axis = 1, trig = 1, blocking = 1|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^FluidProxyUgen.kr(\FluidBufFlattenTrigger,-1,  source, startFrame, numFrames, startChan, numChans, destination, axis, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, axis = 1, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination],
@@ -30,11 +24,8 @@ FluidBufFlatten : FluidBufProcessor {
 
 	*processBlocking  { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, axis = 1, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufFlatten:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufFlatten:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination],

--- a/release-packaging/Classes/FluidBufHPSS.sc
+++ b/release-packaging/Classes/FluidBufHPSS.sc
@@ -7,7 +7,7 @@ FluidBufHPSS : FluidBufProcessor {
 		harmonic = harmonic ? -1;
 		percussive = percussive ? -1;
 		residual = residual ? -1;
-		source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
+		source = this.validateBuffer(source, "source");
 
 		^FluidProxyUgen.kr(\FluidBufHPSSTrigger, -1, source, startFrame, numFrames, startChan, numChans, harmonic, percussive, residual, harmFilterSize, harmFilterSize, percFilterSize, percFilterSize, maskingMode, harmThreshFreq1, harmThreshAmp1, harmThreshFreq2, harmThreshAmp2, percThreshFreq1, percThreshAmp1, percThreshFreq2, percThreshAmp2, windowSize, hopSize, fftSize, maxFFTSize,  trig, blocking
 		);
@@ -20,8 +20,7 @@ FluidBufHPSS : FluidBufProcessor {
 		harmonic = harmonic ? -1;
 		percussive = percussive ? -1;
 		residual = residual ? -1;
-		source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
-
+		source = this.validateBuffer(source, "source");
 
 		^this.new(
 			server, nil, [harmonic, percussive, residual].select{|x| x!= -1}
@@ -38,8 +37,7 @@ FluidBufHPSS : FluidBufProcessor {
 		harmonic = harmonic ? -1;
 		percussive = percussive ? -1;
 		residual = residual ? -1;
-		source.isNil.if {"FluidBufHPSS:  Invalid source buffer".throw};
-
+		source = this.validateBuffer(source, "source");
 
 		^this.new(
 			server, nil, [harmonic, percussive, residual].select{|x| x!= -1}

--- a/release-packaging/Classes/FluidBufLoudness.sc
+++ b/release-packaging/Classes/FluidBufLoudness.sc
@@ -1,36 +1,13 @@
 FluidBufLoudness : FluidBufProcessor{
 
-	const <features=#[\loudness, \peak];
-	classvar featuresLookup;
-
-	*initClass {
-		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
-	}
-
-	*prWarnUnrecognised {|sym| ("WARNING: FluidLoudness -" + sym + "is not a recognised option").postln}
-
-	*prProcessSelect {|a|
-		var bits;
-		a.asBag.countsDo{|item,count,i|
-			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-		};
-		bits = a.collect{ |sym|
-			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-		}.reduce{|x,y| x | y};
-		^bits
-	}
-
-	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, padding = 1, trig = 1, blocking = 0|
+	*kr { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, padding = 1, trig = 1, blocking = 0|
 
 		var maxwindowSize = windowSize.nextPowerOfTwo;
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = FluidLoudness.featuresLookup.encode(select);
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-		features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^FluidProxyUgen.kr(\FluidBufLoudnessTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, kWeighting, truePeak, windowSize, hopSize, maxwindowSize, trig, blocking);
 	}
@@ -39,13 +16,10 @@ FluidBufLoudness : FluidBufProcessor{
 
 		var maxwindowSize = windowSize.nextPowerOfTwo;
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = FluidLoudness.featuresLookup.encode(select);
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-		features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]
@@ -58,13 +32,10 @@ FluidBufLoudness : FluidBufProcessor{
 
 		var maxwindowSize = windowSize.nextPowerOfTwo;
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = FluidLoudness.featuresLookup.encode(select);
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-		features.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufMFCC.sc
+++ b/release-packaging/Classes/FluidBufMFCC.sc
@@ -2,11 +2,8 @@ FluidBufMFCC : FluidBufProcessor{
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^FluidProxyUgen.kr(\FluidBufMFCCTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, numCoeffs, numCoeffs, numBands, numBands, startCoeff, minFreq, maxFreq, windowSize, hopSize, fftSize, maxFFTSize,trig, blocking);
 	}
@@ -14,11 +11,8 @@ FluidBufMFCC : FluidBufProcessor{
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone=true, action |
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil,[features]
@@ -30,11 +24,8 @@ FluidBufMFCC : FluidBufProcessor{
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, numCoeffs = 13, numBands = 40, startCoeff = 0, minFreq = 20, maxFreq = 20000, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone=true, action |
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufMFCC:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufMFCC:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil,[features]

--- a/release-packaging/Classes/FluidBufMelBands.sc
+++ b/release-packaging/Classes/FluidBufMelBands.sc
@@ -4,12 +4,8 @@ FluidBufMelBands : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
-
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^FluidProxyUgen.kr(\FluidBufMelBandsTrigger,-1, source, startFrame, numFrames, startChan, numChans, features, padding, numBands, numBands,  minFreq, maxFreq,  normalize, scale, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
@@ -18,11 +14,8 @@ FluidBufMelBands : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]
@@ -35,11 +28,8 @@ FluidBufMelBands : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufMelBands:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufMelBands:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufNMF.sc
+++ b/release-packaging/Classes/FluidBufNMF.sc
@@ -2,7 +2,7 @@ FluidBufNMF : FluidBufProcessor
 {
 	*kr  {|source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth, resynthMode = 0,  bases, basesMode = 0, activations, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-		source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
+		source = this.validateBuffer(source, "source");
 		resynth = resynth ? -1;
 		bases = bases ? -1;
 		activations = activations ? -1;
@@ -12,7 +12,7 @@ FluidBufNMF : FluidBufProcessor
 
 	*process { |server,  source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth = -1, resynthMode = 0,  bases = -1, basesMode = 0, activations = -1, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1,freeWhenDone = true, action|
 
-		source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
+		source = this.validateBuffer(source, "source");
 		resynth = resynth ? -1;
 		bases = bases ? -1;
 		activations = activations ? -1;
@@ -24,7 +24,7 @@ FluidBufNMF : FluidBufProcessor
 
 	*processBlocking { |server,  source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, resynth = -1, resynthMode = 0, bases = -1, basesMode = 0, activations = -1, actMode = 0, components = 1, iterations = 100, windowSize = 1024, hopSize = -1, fftSize = -1,freeWhenDone = true, action|
 
-		source.isNil.if {"FluidBufNMF:  Invalid source buffer".throw};
+		source = this.validateBuffer(source, "source");
 		resynth = resynth ? -1;
 		bases = bases ? -1;
 		activations = activations ? -1;

--- a/release-packaging/Classes/FluidBufNMFCross.sc
+++ b/release-packaging/Classes/FluidBufNMFCross.sc
@@ -2,25 +2,18 @@ FluidBufNMFCross : FluidBufProcessor {
 
 	*kr  { |source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-		source = source.asUGenInput;
-		target = target.asUGenInput;
-		output = output.asUGenInput;
-		source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
-		target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
-		output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
+		source = this.validateBuffer(source, "source");
+		target = this.validateBuffer(target, "target");
+		output = this.validateBuffer(output, "output");
 
 		^FluidProxyUgen.kr(\FluidBufNMFCrossTrigger, -1, source, target, output, timeSparsity, polyphony, continuity, iterations,  windowSize, hopSize, fftSize, fftSize, trig, blocking);
 	}
 
 	*process { |server, source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		target = target.asUGenInput;
-		output = output.asUGenInput;
-		source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
-		target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
-		output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
-
+		source = this.validateBuffer(source, "source");
+		target = this.validateBuffer(target, "target");
+		output = this.validateBuffer(output, "output");
 
 		^this.new(
 			server, nil, [output]
@@ -31,13 +24,9 @@ FluidBufNMFCross : FluidBufProcessor {
 
 	*processBlocking { |server, source, target, output , timeSparsity = 7, polyphony = 10, continuity = 7, iterations = 50, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		target = target.asUGenInput;
-		output = output.asUGenInput;
-		source.isNil.if {"FluidBufNMFCross:  Invalid source buffer".throw};
-		target.isNil.if {"FluidBufNMFCross:  Invalid target buffer".throw};
-		output.isNil.if {"FluidBufNMFCross:  Invalid output buffer".throw};
-
+		source = this.validateBuffer(source, "source");
+		target = this.validateBuffer(target, "target");
+		output = this.validateBuffer(output, "output");
 
 		^this.new(
 			server, nil, [output]

--- a/release-packaging/Classes/FluidBufNMFSeed.sc
+++ b/release-packaging/Classes/FluidBufNMFSeed.sc
@@ -2,12 +2,9 @@ FluidBufNMFSeed : FluidBufProcessor{
 
 	*kr  { |source, bases, activations, minComponents = 1, maxComponents = 200, coverage = 0.5, method = 0, windowSize = 1024, hopSize = -1, fftSize = -1, trig = 1, blocking = 0|
 
-		source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
-		bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-		activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-		source = source.asUGenInput;
-		bases = bases.asUGenInput;
-		activations = activations.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		bases = this.validateBuffer(bases, "bases");
+		activations = this.validateBuffer(activations, "activations");
 
 		^FluidProxyUgen.kr1(\FluidBufNMFSeedTrigger, -1, source, bases, activations, minComponents, maxComponents, coverage, method, windowSize, hopSize, fftSize, fftSize, trig, blocking);
 	}
@@ -15,12 +12,9 @@ FluidBufNMFSeed : FluidBufProcessor{
 
 	*process { |server, source, bases, activations, minComponents = 1, maxComponents = 200, coverage = 0.5, method = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-		source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
-		bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-		activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-		source = source.asUGenInput;
-		bases = bases.asUGenInput;
-		activations = activations.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		bases = this.validateBuffer(bases, "bases");
+		activations = this.validateBuffer(activations, "activations");
 
 		^this.new(
 			server, nil, [bases,activations]
@@ -31,12 +25,9 @@ FluidBufNMFSeed : FluidBufProcessor{
 
 	*processBlocking { |server, source, bases, activations, minComponents = 1, maxComponents = 200, coverage = 0.5, method = 0, windowSize = 1024, hopSize = -1, fftSize = -1, freeWhenDone = true, action|
 
-		source.isNil.if {"FluidBufNMFSeed:  Invalid source buffer".throw};
-		bases.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-		activations.isNil.if {"FluidBufNMFSeed:  Invalid bases buffer".throw};
-		source = source.asUGenInput;
-		bases = bases.asUGenInput;
-		activations = activations.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		bases = this.validateBuffer(bases, "bases");
+		activations = this.validateBuffer(activations, "activations");
 
 		^this.new(
 			server, nil, [bases,activations]

--- a/release-packaging/Classes/FluidBufNoveltyFeature.sc
+++ b/release-packaging/Classes/FluidBufNoveltyFeature.sc
@@ -4,15 +4,12 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")
 			.format(algorithm).throw;
 		};
-
-		source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufNoveltyFeatureTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, algorithm, kernelSize, kernelSize, filterSize, filterSize, windowSize, hopSize, fftSize, maxFFTSize,  trig, blocking);
 
@@ -22,16 +19,13 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
 		if (algorithm.isNil or: algorithm.isUGen) {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")
 			.format(algorithm).throw;
 		};
-
-		source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
@@ -44,11 +38,9 @@ FluidBufNoveltyFeature : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
-		source.isNil.if {"FluidBufNoveltyFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufNoveltyFeature:  Invalid features buffer".throw};
 		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
 		if (algorithm.isNil or: algorithm.isUGen) {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")

--- a/release-packaging/Classes/FluidBufNoveltySlice.sc
+++ b/release-packaging/Classes/FluidBufNoveltySlice.sc
@@ -4,15 +4,12 @@ FluidBufNoveltySlice : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm) ?? {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")
 			.format(algorithm).throw;
 		};
-
-		source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufNoveltySliceTrigger, -1, source, startFrame, numFrames, startChan, numChans, indices, algorithm, kernelSize, kernelSize, threshold, filterSize, filterSize, minSliceLength, windowSize, hopSize, fftSize, maxFFTSize,  trig, blocking);
 
@@ -22,16 +19,13 @@ FluidBufNoveltySlice : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
 		if (algorithm.isNil or: algorithm.isUGen) {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")
 			.format(algorithm).throw;
 		};
-
-		source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [indices]
@@ -44,16 +38,13 @@ FluidBufNoveltySlice : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 		algorithm = FluidNoveltySlice.prSelectAlgorithm(algorithm);
 		if (algorithm.isNil or: algorithm.isUGen) {
 			("FluidBufNoveltySlice: % is not a recognised algorithm")
 			.format(algorithm).throw;
 		};
-
-		source.isNil.if {"FluidBufNoveltySlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufNoveltySlice:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [indices]

--- a/release-packaging/Classes/FluidBufOnsetFeature.sc
+++ b/release-packaging/Classes/FluidBufOnsetFeature.sc
@@ -3,15 +3,12 @@ FluidBufOnsetFeature : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 		metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
 			("FluidBufOnsetSlice: % is not a recognised metric")
 			.format(metric).throw;
 		};
-
-		source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufOnsetFeatureTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, metric, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
@@ -20,16 +17,13 @@ FluidBufOnsetFeature : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 		metric = FluidOnsetSlice.prSelectMetric(metric);
 		if (metric.isNil or: metric.isUGen) {
 			("FluidBufOnsetSlice: % is not a recognised metric")
 			.format(metric).throw;
 		};
-
-		source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]
@@ -42,16 +36,13 @@ FluidBufOnsetFeature : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 		metric = FluidOnsetSlice.prSelectMetric(metric);
 		if (metric.isNil or: metric.isUGen) {
 			("FluidBufOnsetSlice: % is not a recognised metric")
 			.format(metric).throw;
 		};
-
-		source.isNil.if {"FluidBufOnsetFeature:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufOnsetFeature:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufOnsetSlice.sc
+++ b/release-packaging/Classes/FluidBufOnsetSlice.sc
@@ -4,15 +4,12 @@ FluidBufOnsetSlice : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 		metric = FluidOnsetSlice.prSelectMetric(metric) ?? {
 			("FluidBufOnsetSlice: % is not a recognised metric")
 			.format(metric).throw;
 		};
-
-		source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufOnsetSliceTrigger, -1, source, startFrame, numFrames, startChan, numChans, indices, metric, threshold, minSliceLength, filterSize, frameDelta, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
@@ -21,16 +18,13 @@ FluidBufOnsetSlice : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 		metric = FluidOnsetSlice.prSelectMetric(metric);
 		if (metric.isNil or: metric.isUGen) {
 			("FluidBufOnsetSlice: % is not a recognised metric")
 			.format(metric).throw;
 		};
-
-		source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [indices]
@@ -43,16 +37,13 @@ FluidBufOnsetSlice : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 		metric = FluidOnsetSlice.prSelectMetric(metric);
 		if (metric.isNil or: metric.isUGen) {
 			("FluidBufOnsetSlice: % is not a recognised metric")
 			.format(metric).throw;
 		};
-
-		source.isNil.if {"FluidBufOnsetSlice:  Invalid source buffer".throw};
-		indices.isNil.if {"FluidBufOnsetSlice:  Invalid features buffer".throw};
 
 		^this.new(
 			server, nil, [indices]

--- a/release-packaging/Classes/FluidBufPitch.sc
+++ b/release-packaging/Classes/FluidBufPitch.sc
@@ -1,36 +1,13 @@
 FluidBufPitch : FluidBufProcessor{
 
-	const <features=#[\pitch, \confidence];
-	classvar featuresLookup;
-
-	*initClass {
-		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
-	}
-
-	*prWarnUnrecognised {|sym| ("WARNING: FluidBufPitch -" + sym + "is not a recognised option").postln}
-
-	*prProcessSelect {|a|
-		var bits;
-		a.asBag.countsDo{|item,count,i|
-			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-		};
-		bits = a.collect{ |sym|
-			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-		}.reduce{|x,y| x | y};
-		^bits
-	}
-
 	*kr { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features,  select, algorithm = 2, minFreq = 20, maxFreq = 10000, unit = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = FluidPitch.featuresLookup.encode(select);
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^FluidProxyUgen.kr(\FluidBufPitchTrigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, algorithm, minFreq, maxFreq, unit, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 
@@ -40,13 +17,10 @@ FluidBufPitch : FluidBufProcessor{
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = FluidPitch.featuresLookup.encode(select);
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]
@@ -59,13 +33,10 @@ FluidBufPitch : FluidBufProcessor{
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = FluidPitch.featuresLookup.encode(select);
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufPitch:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufPitch:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufScale.sc
+++ b/release-packaging/Classes/FluidBufScale.sc
@@ -2,22 +2,16 @@ FluidBufScale : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, inputLow = 0, inputHigh = 1, outputLow = 0, outputHigh = 1, clipping = 0,  trig = 1, blocking = 1|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^FluidProxyUgen.kr(\FluidBufScaleTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, inputLow, inputHigh, outputLow, outputHigh, clipping, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, inputLow = 0, inputHigh = 1, outputLow = 0, outputHigh = 1, clipping = 0,  freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination]
@@ -28,11 +22,8 @@ FluidBufScale : FluidBufProcessor {
 
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, inputLow = 0, inputHigh = 1, outputLow = 0, outputHigh = 1, clipping = 0,  freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufScale:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufScale:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination]

--- a/release-packaging/Classes/FluidBufSelect.sc
+++ b/release-packaging/Classes/FluidBufSelect.sc
@@ -4,17 +4,14 @@ FluidBufSelect : FluidBufProcessor {
 
 		var params;
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		indices = indices.asArray;
 		channels = channels.asArray;
 
 		indices = [indices.size] ++ indices;
 		channels = [channels.size] ++ channels;
-
-		source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
 
 		params = indices ++ channels ++ [trig, blocking]
 
@@ -24,11 +21,8 @@ FluidBufSelect : FluidBufProcessor {
 
 	*process { |server, source, destination, indices=#[-1], channels=#[-1], freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		indices = indices.asArray;
 		channels = channels.asArray;
@@ -41,11 +35,8 @@ FluidBufSelect : FluidBufProcessor {
 
 	*processBlocking { |server, source, destination, indices=#[-1], channels=#[-1], freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufSelect:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufSelect:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		indices = indices.asArray;
 		channels = channels.asArray;

--- a/release-packaging/Classes/FluidBufSelectEvery.sc
+++ b/release-packaging/Classes/FluidBufSelectEvery.sc
@@ -2,22 +2,16 @@ FluidBufSelectEvery : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, frameHop = 1, chanHop = 1, trig = 1, blocking = 1|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^FluidProxyUgen.kr(\FluidBufSelectEveryTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, frameHop, chanHop, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, frameHop = 1, chanHop = 1, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination]
@@ -28,11 +22,8 @@ FluidBufSelectEvery : FluidBufProcessor {
 
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, frameHop = 1, chanHop = 1, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufSelectEvery:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufSelectEvery:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination]

--- a/release-packaging/Classes/FluidBufSines.sc
+++ b/release-packaging/Classes/FluidBufSines.sc
@@ -4,11 +4,9 @@ FluidBufSines : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
+		source = this.validateBuffer(source, "source");
 		sines = sines !? {sines.asUGenInput} ?? {-1};
 		residual = residual !? {residual.asUGenInput} ?? {-1};
-
-		source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
 
 		^FluidProxyUgen.multiNew(\FluidBufSinesTrigger, -1, source, startFrame, numFrames, startChan, numChans, sines, residual, bandwidth, detectionThreshold,birthLowThreshold, birthHighThreshold, minTrackLen, trackingMethod, trackMagRange, trackFreqRange, trackProb, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 	}
@@ -17,11 +15,9 @@ FluidBufSines : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
+		source = this.validateBuffer(source, "source");
 		sines = sines !? {sines.asUGenInput} ?? {-1};
 		residual = residual !? {residual.asUGenInput} ?? {-1};
-
-		source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
 
 		^this.new(
 			server, nil, [sines, residual].select{|x| x!= -1}
@@ -34,11 +30,9 @@ FluidBufSines : FluidBufProcessor {
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
 
-		source = source.asUGenInput;
+		source = this.validateBuffer(source, "source");
 		sines = sines !? {sines.asUGenInput} ?? {-1};
 		residual = residual !? {residual.asUGenInput} ?? {-1};
-
-		source.isNil.if {"FluidBufSines:  Invalid source buffer".throw};
 
 		^this.new(
 			server, nil, [sines, residual].select{|x| x!= -1}

--- a/release-packaging/Classes/FluidBufSpectralShape.sc
+++ b/release-packaging/Classes/FluidBufSpectralShape.sc
@@ -3,14 +3,9 @@ FluidBufSpectralShape : FluidBufProcessor {
 	*kr { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, trig = 1, blocking = 0|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
-
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufSpectralShape:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufSpectralShape:  Invalid features buffer".throw};
-
+		var selectbits = FluidSpectralShape.featuresLookup.encode(select);
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^FluidProxyUgen.kr(this.objectClassName++\Trigger, -1, source, startFrame, numFrames, startChan, numChans, features, padding, selectbits, minFreq, maxFreq, rolloffPercent, unit, power, windowSize, hopSize, fftSize, maxFFTSize, trig, blocking);
 
@@ -19,13 +14,10 @@ FluidBufSpectralShape : FluidBufProcessor {
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
+		var selectbits = FluidSpectralShape.featuresLookup.encode(select);
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufSpectralShape:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufSpectralShape:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]
@@ -37,13 +29,10 @@ FluidBufSpectralShape : FluidBufProcessor {
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, features, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, padding = 1, freeWhenDone = true, action|
 
 		var maxFFTSize = if (fftSize == -1) {windowSize.nextPowerOfTwo} {fftSize};
-		var selectbits = select !? {FluidSpectralShape.prProcessSelect(select)} ?? {FluidSpectralShape.prProcessSelect(FluidSpectralShape.features)};
+		var selectbits = FluidSpectralShape.featuresLookup.encode(select);
 
-		source = source.asUGenInput;
-		features = features.asUGenInput;
-
-		source.isNil.if {"FluidBufSpectralShape:  Invalid source buffer".throw};
-		features.isNil.if {"FluidBufSpectralShape:  Invalid features buffer".throw};
+		source = this.validateBuffer(source, "source");
+		features = this.validateBuffer(features, "features");
 
 		^this.new(
 			server, nil, [features]

--- a/release-packaging/Classes/FluidBufStats.sc
+++ b/release-packaging/Classes/FluidBufStats.sc
@@ -1,49 +1,28 @@
 FluidBufStats : FluidBufProcessor {
 
 	const <stats=#[\mean,\std,\skewness,\kurtosis,\low,\mid,\high];
-	classvar statslookup;
-
-	*prWarnUnrecognised {|sym| ("WARNING: FluidBufStats -" + sym + "is not a recognised option").postln}
-
-	*prProcessSelect {|a|
-		var bits;
-		a.asBag.countsDo{|item,count,i|
-			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-		};
-		bits = a.collect{ |sym|
-			(statslookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-		}.reduce{|x,y| x | y};
-		^bits
-	}
+	classvar <statslookup;
 
 	*initClass {
-		statslookup = Dictionary.with(*this.stats.collect{|x,i| x->(1<<i)});
+		statslookup = FluidProcessSelect(this, this.stats);
 	}
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, stats, select, numDerivs = 0, low = 0, middle = 50, high = 100, outliersCutoff = -1, weights, trig = 1, blocking = 0|
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
-		source = source.asUGenInput;
-		stats = stats.asUGenInput;
-		weights = weights.asUGenInput;
-
-		source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
-		stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
-		weights = weights ? -1;
+		var selectbits = this.statslookup.encode(select);
+		source = this.validateBuffer(source, "source");
+		stats = this.validateBuffer(stats, "stats");
+		weights = weights.asUGenInput ? -1;
 
 		^FluidProxyUgen.kr(\FluidBufStatsTrigger, -1, source, startFrame, numFrames, startChan, numChans, stats, selectbits, numDerivs, low, middle, high, outliersCutoff, weights, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, stats, select, numDerivs = 0, low = 0, middle = 50, high = 100, outliersCutoff = -1, weights, freeWhenDone = true, action|
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
-		source = source.asUGenInput;
-		stats = stats.asUGenInput;
-		weights = weights.asUGenInput;
-
-		source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
-		stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
-		weights = weights ? -1;
+		var selectbits = this.statslookup.encode(select);
+		source = this.validateBuffer(source, "source");
+		stats = this.validateBuffer(stats, "stats");
+		weights = weights.asUGenInput ? -1;
 
 		^this.new(
 			server, nil, [stats]
@@ -54,13 +33,10 @@ FluidBufStats : FluidBufProcessor {
 
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, stats, select numDerivs = 0, low = 0, middle = 50, high = 100, outliersCutoff = -1, weights, freeWhenDone = true, action|
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.stats)};
-		source = source.asUGenInput;
-		stats = stats.asUGenInput;
-		weights = weights.asUGenInput;
-		source.isNil.if {"FluidBufStats:  Invalid source buffer".throw};
-		stats.isNil.if {"FluidBufStats:  Invalid stats buffer".throw};
-		weights = weights ? -1;
+		var selectbits = this.statslookup.encode(select);
+		source = this.validateBuffer(source, "source");
+		stats = this.validateBuffer(stats, "stats");
+		weights = weights.asUGenInput ? -1;
 
 		^this.new(
 			server, nil, [stats]

--- a/release-packaging/Classes/FluidBufThreadDemo.sc
+++ b/release-packaging/Classes/FluidBufThreadDemo.sc
@@ -2,16 +2,14 @@ FluidBufThreadDemo : FluidBufProcessor{
 
 	*kr  {|result, time, trig = 1, blocking = 0|
 
-		result = result.asUGenInput;
-		result.isNil.if {this.class.name+":  Invalid output buffer".throw};
+		result = this.validateBuffer(result, "result");
 
 		^FluidProxyUgen.kr(\FluidBufThreadDemoTrigger, -1, result, time, trig, blocking);
 	}
 
 	*process { |server, result, time = 1000, freeWhenDone = true, action|
 
-
-		result ?? {this.class.name+":  Invalid output buffer".throw};
+		result = this.validateBuffer(result, "result");
 
 		^this.new(
 			server, nil, [result]
@@ -22,7 +20,7 @@ FluidBufThreadDemo : FluidBufProcessor{
 
 	*processBlocking { |server, result, time = 1000, freeWhenDone = true, action|
 
-		result ?? {this.class.name+":  Invalid output buffer".throw};
+		result = this.validateBuffer(result, "result");
 
 		^this.new(
 			server, nil, [result]

--- a/release-packaging/Classes/FluidBufThresh.sc
+++ b/release-packaging/Classes/FluidBufThresh.sc
@@ -2,22 +2,16 @@ FluidBufThresh : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, destination, threshold = 0, trig = 1, blocking = 1|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^FluidProxyUgen.kr(\FluidBufThreshTrigger, -1, source, startFrame, numFrames, startChan, numChans, destination, threshold, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1,  destination, threshold = 0, freeWhenDone = true,  action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination],
@@ -29,11 +23,8 @@ FluidBufThresh : FluidBufProcessor {
 
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1,  destination, threshold = 0, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		destination = destination.asUGenInput;
-
-		source.isNil.if {"FluidBufThresh:  Invalid source buffer".throw};
-		destination.isNil.if {"FluidBufThresh:  Invalid destination buffer".throw};
+		source = this.validateBuffer(source, "source");
+		destination = this.validateBuffer(destination, "destination");
 
 		^this.new(
 			server, nil, [destination],

--- a/release-packaging/Classes/FluidBufTransientSlice.sc
+++ b/release-packaging/Classes/FluidBufTransientSlice.sc
@@ -2,22 +2,16 @@ FluidBufTransientSlice : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, minSliceLength = 1000, trig = 1, blocking = 0|
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
-
-		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-		indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^FluidProxyUgen.kr(this.objectClassName++\Trigger, -1, source, startFrame, numFrames, startChan, numChans, indices, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, minSliceLength, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, minSliceLength = 1000, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
-
-		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-		indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^this.new(
 			server, nil,[indices]
@@ -27,11 +21,8 @@ FluidBufTransientSlice : FluidBufProcessor {
 
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, indices, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, minSliceLength = 1000, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
-		indices = indices.asUGenInput;
-
-		source.isNil.if {"%:  Invalid source buffer".format(this.class.name).throw};
-		indices.isNil.if {"%:  Invalid features buffer".format(this.class.name).throw};
+		source = this.validateBuffer(source, "source");
+		indices = this.validateBuffer(indices, "indices");
 
 		^this.new(
 			server, nil,[indices]

--- a/release-packaging/Classes/FluidBufTransients.sc
+++ b/release-packaging/Classes/FluidBufTransients.sc
@@ -2,22 +2,18 @@ FluidBufTransients : FluidBufProcessor {
 
 	*kr  { |source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, trig = 1, blocking = 0|
 
-		source = source.asUGenInput;
+		source = this.validateBuffer(source, "source");
 		transients = transients ? -1;
 		residual = residual ? -1;
-
-		source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
 
 		^FluidProxyUgen.kr(\FluidBufTransientsTrigger, -1, source, startFrame, numFrames, startChan, numChans, transients, residual, order, blockSize, padSize, skew, threshFwd, threshBack, windowSize, clumpLength, trig, blocking);
 	}
 
 	*process { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
+		source = this.validateBuffer(source, "source");
 		transients = transients ? -1;
 		residual = residual ? -1;
-
-		source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
 
 		^this.new(
 			server, nil,[transients, residual].select{|x| x!= -1}
@@ -28,11 +24,9 @@ FluidBufTransients : FluidBufProcessor {
 
 	*processBlocking { |server, source, startFrame = 0, numFrames = -1, startChan = 0, numChans = -1, transients = -1, residual = -1, order = 20, blockSize = 256, padSize = 128, skew = 0, threshFwd = 2, threshBack = 1.1, windowSize = 14, clumpLength = 25, freeWhenDone = true, action|
 
-		source = source.asUGenInput;
+		source = this.validateBuffer(source, "source");
 		transients = transients ? -1;
 		residual = residual ? -1;
-
-		source.isNil.if {"FluidBufTransients:  Invalid source buffer".throw};
 
 		^this.new(
 			server, nil,[transients, residual].select{|x| x!= -1}

--- a/release-packaging/Classes/FluidLoudness.sc
+++ b/release-packaging/Classes/FluidLoudness.sc
@@ -1,28 +1,15 @@
 FluidLoudness : FluidRTMultiOutUGen {
 
 	const <features=#[\loudness, \peak];
-	classvar featuresLookup;
+	classvar <featuresLookup;
 
 	*initClass {
-		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
-	}
-
-	*prWarnUnrecognised {|sym| ("WARNING: FluidLoudness -" + sym + "is not a recognised option").postln}
-
-	*prProcessSelect {|a|
-		var bits;
-		a.asBag.countsDo{|item,count,i|
-			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-		};
-		bits = a.collect{ |sym|
-			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-		}.reduce{|x,y| x | y};
-		^bits
+		featuresLookup = FluidProcessSelect(this, this.features);
 	}
 
 	*kr { arg in = 0, select, kWeighting = 1, truePeak = 1, windowSize = 1024, hopSize = 512, maxWindowSize = 16384;
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = this.featuresLookup.encode(select);
 
 		^this.multiNew('control', in.asAudioRateInput(this), selectbits, kWeighting, truePeak, windowSize, hopSize, maxWindowSize);
 	}

--- a/release-packaging/Classes/FluidPitch.sc
+++ b/release-packaging/Classes/FluidPitch.sc
@@ -1,29 +1,15 @@
 FluidPitch : FluidRTMultiOutUGen {
 
 	const <features=#[\pitch, \confidence];
-	classvar featuresLookup;
+	classvar <featuresLookup;
 
 	*initClass {
-		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
+		featuresLookup = FluidProcessSelect(this, this.features);
 	}
-
-	*prWarnUnrecognised {|sym| ("WARNING: FluidPitch -" + sym + "is not a recognised option").postln}
-
-	*prProcessSelect {|a|
-		var bits;
-		a.asBag.countsDo{|item,count,i|
-			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-		};
-		bits = a.collect{ |sym|
-			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-		}.reduce{|x,y| x | y};
-		^bits
-	}
-
 
 	*kr { arg in = 0, select, algorithm = 2, minFreq = 20, maxFreq = 10000, unit = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = this.featuresLookup.encode(select);
 
 		^this.multiNew('control', in.asAudioRateInput(this), selectbits, algorithm, minFreq, maxFreq, unit, windowSize, hopSize, fftSize, maxFFTSize);
 	}

--- a/release-packaging/Classes/FluidProcessSelect.sc
+++ b/release-packaging/Classes/FluidProcessSelect.sc
@@ -1,0 +1,30 @@
+FluidProcessSelect {
+	var processClass, options;
+	var lookupDict, defaultSelection, defaultBits;
+
+	*new { |processClass, options, defaultSelection|
+		^super.newCopyArgs(processClass, options).init(defaultSelection)
+	}
+
+	init { |default|
+		lookupDict = Dictionary.with(*options.collect{|x,i| x->(1<<i)});
+		defaultSelection = (default ? options).asArray;
+		defaultBits = this.encode(defaultSelection);
+	}
+
+	encode {|a|
+		var bits;
+		a = (a ?? defaultSelection).asArray;
+		a.asBag.countsDo{ |item, count, i|
+			if(count > 1) { "Option '%' is repeated".format(item).warn };
+		};
+		bits = a.collect{ |sym|
+			(lookupDict[sym.asSymbol] ?? { this.prWarnUnrecognised(sym); 0 })
+		}.reduce{ |x, y| x | y };
+		^bits ?? defaultBits
+	}
+
+	prWarnUnrecognised {|sym|
+		"% - '%' is not a recognised option".format(processClass, sym).warn
+	}
+}

--- a/release-packaging/Classes/FluidServerObject.sc
+++ b/release-packaging/Classes/FluidServerObject.sc
@@ -196,6 +196,14 @@ FluidBufProcessor : FluidServerObject
 	}
 
 	kr{  ^FluidProxyUgen.kr(this.class.objectClassName ++ "Monitor",id) }
+
+	*validateBuffer { |buf, bufName=""|
+		buf = buf.asUGenInput;
+		if (buf.isNil) {
+			Error("%:  Invalid % buffer".format(this.name, bufName)).throw;
+		};
+		^buf
+	}
 }
 
 FluidOSCPatternInversion : OSCMessageDispatcher

--- a/release-packaging/Classes/FluidSpectralShape.sc
+++ b/release-packaging/Classes/FluidSpectralShape.sc
@@ -1,29 +1,15 @@
 FluidSpectralShape : FluidRTMultiOutUGen {
 
 	const <features=#[\centroid,\spread,\skewness,\kurtosis,\rolloff,\flatness,\crest];
-	classvar featuresLookup;
+	classvar <featuresLookup;
 
 	*initClass {
-		featuresLookup = Dictionary.with(*this.features.collect{|x,i| x->(1<<i)});
+		featuresLookup = FluidProcessSelect(this, this.features);
 	}
-
-	*prWarnUnrecognised {|sym| ("WARNING: FluidSpectralShape -" + sym + "is not a recognised option").postln}
-
-	*prProcessSelect {|a|
-		var bits;
-		a.asBag.countsDo{|item,count,i|
-			if(count > 1) { ("Option '" ++ item ++ "' is repeated").warn};
-		};
-		bits = a.collect{ |sym|
-			(featuresLookup[sym.asSymbol] !? {|x| x} ?? {this.prWarnUnrecognised(sym); 0})
-		}.reduce{|x,y| x | y};
-		^bits
-	}
-
 
 	*kr { arg in = 0, select, minFreq = 0, maxFreq = -1, rolloffPercent = 95, unit = 0, power = 0, windowSize = 1024, hopSize = -1, fftSize = -1, maxFFTSize = -1;
 
-		var selectbits  =  select !? {this.prProcessSelect(select)} ?? {this.prProcessSelect(this.features)};
+		var selectbits = this.featuresLookup.encode(select);
 
 		^this.multiNew('control', in.asAudioRateInput(this), selectbits, minFreq, maxFreq, rolloffPercent, unit, power, windowSize, hopSize, fftSize, maxFFTSize);
 	}


### PR DESCRIPTION
to remove duplicate code scattered over many classes, prProcessSelect becomes FluidProcessSelect, and buffer validation for BufProcessors is now a method inherited from FluidBufProcessor.

FluidProcessSelect usage:
```sclang
// FluidSpectralShape
const <features=#[\centroid,\spread,\skewness,\kurtosis,\rolloff,\flatness,\crest];
classvar <featuresLookup;
*initClass {
	featuresLookup = FluidProcessSelect(this, this.features);
}
*kr { 
   [...]
   var selectbits = this.featuresLookup.encode(select);
   [...]
}
```

validateBuffer: converts with `.asUGenInput`, checks for nil, and throws on error
```
// e.g FluidBufPitch
*kr {
    [...]
    source = this.validateBuffer(source, "source");
    [...]
}
// example error: the class name and the second argument are used in the error message
// FluidBufPitch:  Invalid source buffer
```

Let me know if you like it :)