### PR TITLE
KDTree KR supports the same behaviour than the NRT query

### DIFF
--- a/release-packaging/Classes/FluidKDTree.sc
+++ b/release-packaging/Classes/FluidKDTree.sc
@@ -48,13 +48,9 @@ FluidKDTree : FluidModelObject
 		this.prSendMsg(this.kNearestDistMsg(buffer,k));
 	}
 
-	kr{|trig, inputBuffer,outputBuffer, numNeighbours = 1, lookupDataSet|
-		/*        this.numNeighbours_(numNeighbours);
-		lookupDataSet = lookupDataSet ? -1;
-		this.lookupDataSet_(lookupDataSet);*/
-
+	kr{|trig, inputBuffer, outputBuffer, numNeighbours, radius, lookupDataSet|
 		^FluidKDTreeQuery.kr(trig,
-			this, numNeighbours, this.radius,lookupDataSet.asUGenInput,
+			this, numNeighbours??{this.numNeighbours}, radius??{this.radius}, lookupDataSet.asUGenInput,
 			inputBuffer,outputBuffer);
 	}
 
@@ -62,8 +58,8 @@ FluidKDTree : FluidModelObject
 
 FluidKDTreeQuery : FluidRTMultiOutUGen
 {
-	*kr{ |trig, tree, numNeighbours, radius,lookupDataSet, inputBuffer, outputBuffer |
-		^this.multiNew('control',trig, tree.asUGenInput, numNeighbours, radius,lookupDataSet!?(_.asUGenInput)??{-1}, inputBuffer.asUGenInput, outputBuffer.asUGenInput)
+	*kr{ |trig, tree, numNeighbours, radius, lookupDataSet, inputBuffer, outputBuffer |
+		^this.multiNew('control', trig, tree.asUGenInput, numNeighbours, radius, lookupDataSet!?(_.asUGenInput)??{-1}, inputBuffer.asUGenInput, outputBuffer.asUGenInput)
 	}
 
 	init { arg ... theInputs;


### PR DESCRIPTION
This gives the RT querying (kr) the same behaviour than the NRT, when radius=0 returns all up to k, and k=0 returns all in radius. 

the size of the output buffer is a hard cap on the number of points returned.

the KR out is the number of valid points in the buffer.

test code:

```supercollider
a = Dictionary.newFrom([\cols, 3, \data, Dictionary.newFrom(4.collect{|i|[i.asSymbol, i.dup(3)]}.flatten)])

d = FluidDataSet(s)
d.load(a)
d.print

b = Buffer.alloc(s,6)
c = Buffer.alloc(s,3)

k = FluidKDTree(s)
k.fit(d)

x= {arg nb = 1, radius = 0; var poke = Impulse.kr(1); k.kr(poke,c,b,nb,radius).poll(poke); FluidBufToKr.kr(b).poll(poke); Silent.ar();}.play

c.sendCollection(1.5.dup(3)) //try on the spot, and without. fun

x.set(\nb, 0)
x.set(\radius, 0.01)
```