### PR TITLE
EOL `.gitattributes` normalisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+* text=auto
+
+*.cmake text
+*.cpp text
+*.csv text
+*.gitignore text
+*.hpp text
+*.in text
+*.json text
+*.md text
+*.sc text
+*.scd text
+*.schelp text
+*.txt text
+*.yaml text
+*.yml text
+
+*.png binary


### PR DESCRIPTION
EOL standardisation with .gitattributes to fix issues with versions of Git before 2.10 allowed automatic EOL conversion.