### PR TITLE
added initialize variable to the class definition

### DIFF
--- a/release-packaging/Classes/FluidSKMeans.sc
+++ b/release-packaging/Classes/FluidSKMeans.sc
@@ -1,12 +1,13 @@
 FluidSKMeans : FluidModelObject {
 
-	var clusters, threshold, maxiter;
+	var clusters, threshold, maxiter, initialize;
 
-	*new {|server, numClusters = 4, encodingThreshold = 0.25, maxIter = 100|
-		^super.new(server,[numClusters,maxIter, encodingThreshold])
+	*new {|server, numClusters = 4, encodingThreshold = 0.25, maxIter = 100, initialize = 0|
+		^super.new(server,[numClusters, maxIter, encodingThreshold, initialize])
 		.numClusters_(numClusters)
 		.encodingThreshold_(encodingThreshold)
-		.maxIter_(maxIter);
+		.maxIter_(maxIter)
+		.initialize_(initialize);
 	}
 
 	numClusters_{|n| clusters = n.asInteger}
@@ -18,8 +19,10 @@ FluidSKMeans : FluidModelObject {
 	maxIter_{|i| maxiter = i.asInteger}
 	maxIter{ ^maxiter }
 
+	initialize_{|i| initialize = i.asInteger}
+	initialize{ ^initialize }
 
-	prGetParams{^[this.id,this.numClusters, this.encodingThreshold, this.maxIter];}
+	prGetParams{^[this.id,this.numClusters, this.encodingThreshold, this.maxIter, this.initialize];}
 
 	fitMsg{ |dataSet| ^this.prMakeMsg(\fit,id,dataSet.id);}
 


### PR DESCRIPTION
this seems to work, although with the code below I do not see much of an improvment, so maybe have done something wrong

```
~ds = FluidDataSet(s).read("/Users/pa/Documents/recherche/projets/flucoma/sources/flucoma-max/misc/rays.json");

(
~ds.dump({
	arg dict;
	defer{
		~fp = FluidPlotter(dict:dict,xmin:-1,ymin:-1).pointSizeScale_(3);
	};
});
)

(
~ls = FluidLabelSet(s);
~skm = FluidSKMeans(s,maxIter: 1000);
)

// 10 inits, graphically, one per second
(
Routine{10.do{
~skm.clear;
~skm.fitPredict(~ds,~ls,{
			~ls.dump({
				arg dict;
				~fp.categories_(dict);
	})
});
	1.wait;
};}.play;
)

// rerun above with other initialisation
~skm.initialize_(1)
```