### PR TITLE
update flucoma-core includes

### DIFF
--- a/include/FluidSCWrapper.hpp
+++ b/include/FluidSCWrapper.hpp
@@ -14,7 +14,7 @@ under the European Union’s Horizon 2020 research and innovation programme
 #include "wrapper/DeriveBaseClass.hpp"
 #include "wrapper/NonRealtime.hpp"
 #include "wrapper/Realtime.hpp"
-#include <FluidVersion.hpp>
+#include <flucoma/FluidVersion.hpp>
 
 namespace fluid {
 namespace client {

--- a/include/SCBufferAdaptor.hpp
+++ b/include/SCBufferAdaptor.hpp
@@ -11,8 +11,8 @@ under the European Union’s Horizon 2020 research and innovation programme
 #pragma once
 
 #include <boost/align/aligned_alloc.hpp>
-#include <clients/common/BufferAdaptor.hpp>
-#include <data/FluidTensor.hpp>
+#include <flucoma/clients/common/BufferAdaptor.hpp>
+#include <flucoma/data/FluidTensor.hpp>
 #include <SC_Errors.h>
 #include <SC_PlugIn.h>
 #include <cctype>

--- a/include/clients/rt/FluidDataSetWr.hpp
+++ b/include/clients/rt/FluidDataSetWr.hpp
@@ -1,19 +1,19 @@
 #pragma once
 
-#include <clients/common/FluidBaseClient.hpp>
-#include <clients/common/FluidNRTClientWrapper.hpp>
-#include <clients/common/MessageSet.hpp>
-#include <clients/common/OfflineClient.hpp>
-#include <clients/common/ParameterSet.hpp>
-#include <clients/common/ParameterTypes.hpp>
-#include <clients/common/Result.hpp>
-#include <clients/common/SharedClientUtils.hpp>
-#include <clients/nrt/CommonResults.hpp>
-#include <clients/nrt/DataSetClient.hpp>
-#include <data/FluidDataSet.hpp>
-#include <data/FluidIndex.hpp>
-#include <data/FluidTensor.hpp>
-#include <data/TensorTypes.hpp>
+#include <flucoma/clients/common/FluidBaseClient.hpp>
+#include <flucoma/clients/common/FluidNRTClientWrapper.hpp>
+#include <flucoma/clients/common/MessageSet.hpp>
+#include <flucoma/clients/common/OfflineClient.hpp>
+#include <flucoma/clients/common/ParameterSet.hpp>
+#include <flucoma/clients/common/ParameterTypes.hpp>
+#include <flucoma/clients/common/Result.hpp>
+#include <flucoma/clients/common/SharedClientUtils.hpp>
+#include <flucoma/clients/nrt/CommonResults.hpp>
+#include <flucoma/clients/nrt/DataSetClient.hpp>
+#include <flucoma/data/FluidDataSet.hpp>
+#include <flucoma/data/FluidIndex.hpp>
+#include <flucoma/data/FluidTensor.hpp>
+#include <flucoma/data/TensorTypes.hpp>
 #include <string>
 
 namespace fluid {

--- a/include/wrapper/ArgsFromClient.hpp
+++ b/include/wrapper/ArgsFromClient.hpp
@@ -1,7 +1,7 @@
 #pragma once 
 
 #include "Meta.hpp"
-#include <data/FluidMemory.hpp>
+#include <flucoma/data/FluidMemory.hpp>
 #include <fmt/format.h>
 
 namespace fluid {

--- a/include/wrapper/ArgsToClient.hpp
+++ b/include/wrapper/ArgsToClient.hpp
@@ -1,6 +1,6 @@
 #pragma once 
 
-#include <data/FluidMemory.hpp>
+#include <flucoma/data/FluidMemory.hpp>
 
 namespace fluid {
 namespace client {

--- a/include/wrapper/Meta.hpp
+++ b/include/wrapper/Meta.hpp
@@ -1,8 +1,8 @@
 #pragma once 
 
-#include <clients/nrt/FluidSharedInstanceAdaptor.hpp>
-#include <clients/common/FluidNRTClientWrapper.hpp>
-#include <clients/common/SharedClientUtils.hpp>
+#include <flucoma/clients/nrt/FluidSharedInstanceAdaptor.hpp>
+#include <flucoma/clients/common/FluidNRTClientWrapper.hpp>
+#include <flucoma/clients/common/SharedClientUtils.hpp>
 
 namespace fluid {
 namespace client {

--- a/include/wrapper/NonRealtime.hpp
+++ b/include/wrapper/NonRealtime.hpp
@@ -7,8 +7,8 @@
 #include "RealTimeBase.hpp"
 #include "SCBufferAdaptor.hpp"
 #include "SCWorldAllocator.hpp"
-#include <clients/common/FluidBaseClient.hpp>
-#include <data/FluidMeta.hpp>
+#include <flucoma/clients/common/FluidBaseClient.hpp>
+#include <flucoma/data/FluidMeta.hpp>
 #include <SC_PlugIn.hpp>
 #include <mutex>
 #include <scsynthsend.h>

--- a/include/wrapper/RealTimeBase.hpp
+++ b/include/wrapper/RealTimeBase.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Eigen/Core>
-#include <data/FluidMemory.hpp>
+#include <flucoma/data/FluidMemory.hpp>
 #include <SC_PlugIn.hpp>
 
 namespace fluid {

--- a/include/wrapper/Realtime.hpp
+++ b/include/wrapper/Realtime.hpp
@@ -4,7 +4,7 @@
 #include "Meta.hpp"
 #include "RealTimeBase.hpp"
 #include "SCWorldAllocator.hpp"
-#include <clients/common/FluidBaseClient.hpp>
+#include <flucoma/clients/common/FluidBaseClient.hpp>
 #include <SC_PlugIn.hpp>
 
 // Real Time Processor


### PR DESCRIPTION
adjusts `#includes` of flucoma-core headers for the correspondingly named PR branch on core: https://github.com/flucoma/flucoma-core/pull/297