### PR TITLE
Make FluidFilesPath class more robust

### DIFF
--- a/release-packaging/Classes/FluidFilesPath.sc
+++ b/release-packaging/Classes/FluidFilesPath.sc
@@ -1,7 +1,15 @@
 FluidFilesPath {
+
+	classvar resourcePath;
+
 	*new {
 		arg fileName;
+
+		resourcePath = resourcePath ? Main.packages.collect{|a|
+			(a.value +/+ "Resources/AudioFiles/Tremblay*").pathMatch
+		}.flatten[0].dirname;
+
 		fileName = fileName ? "";
-		^("%/../Resources/AudioFiles/".format(File.realpath(FluidDataSet.class.filenameSymbol).dirname) +/+ fileName);
+		^(resourcePath +/+ fileName);
 	}
 }


### PR DESCRIPTION
Non-urgent quality of life improvement for devs: 

It's a relatively trivial change, but smacks of Being Clever, so I'd be grateful if @tedmoore could look it over and see if there's something I've not considered. 

`FluidFilesPath` works ok at the moment, but relies on a relative path formulation to guess where the resources directory is. 

I've come across an edge case that breaks this whilst putting together an improved development experience that creates a mimic of the final installed package layout, but with symlinks for everything\*. At this point, using a relative path in sclang breaks, because it just sees through the symlinks and looks in the wrong place for the resources folder. 

What this does instead is – once – scans through all the packages that `Main.packages` knows about, and looks for path matches likely to be unique to flucoma (`Resources/AudioFiles/Tremblay*`), in order to reliably locate the actual package directory on disk (whether populated by symlinks or not). 


\* Which is really cool (you can edit classes and help files in place, and everything just works! Except this) – it's all part of a cmake overhaul